### PR TITLE
Add support for ConfigMap to choose connection between Loki or LokiStack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/node:16 AS build
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app
-RUN yarn install --network-timeout 1000000 && yarn build
+RUN npm install && npm run build
 
 FROM docker.io/library/nginx:stable
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ might fail since it runs an amd64 image. You can workaround the problem with
 [qemu-user-static](https://github.com/multiarch/qemu-user-static) by running
 these commands:
 
-```bash
+```sh
 podman machine ssh
 sudo -i
 rpm-ostree install qemu-user-static
@@ -55,22 +55,22 @@ systemctl reboot
 
 #### Unit tests
 
-```shell
+```sh
 npm run test:unit
 ```
 
 #### e2e tests
 
-In order to run the e2e tests, you need to build and run the plugin in standalone mode in one console.
+In order to run the e2e tests, you need first to build the plugin in standalone mode
 
-```shell
-npm run build:standalone:instrumented && npm run start:standalone
+```sh
+npm run build:standalone:instrumented
 ```
 
-and run the cypress tests in a different console.
+and then run the cypress tests
 
-```shell
-npm run cypress:run
+```sh
+npm run test:e2e
 ```
 
 ## Deployment on cluster
@@ -89,4 +89,10 @@ config to enable the plugin.
 ```sh
 oc patch consoles.operator.openshift.io cluster \
   --patch '{ "spec": { "plugins": ["logging-view-plugin"] } }' --type=merge
+```
+
+## Build the image
+
+```sh
+./scripts/image.sh -t latest
 ```

--- a/cypress/e2e/logs-page.cy.ts
+++ b/cypress/e2e/logs-page.cy.ts
@@ -8,9 +8,9 @@ import {
 
 const LOGS_PAGE_URL = '/monitoring/logs';
 const QUERY_RANGE_STREAMS_URL_MATCH =
-  '/api/proxy/plugin/logging-view-plugin/backend/loki/api/v1/query_range?query=%7B*';
+  '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application/loki/api/v1/query_range?query=%7B*';
 const QUERY_RANGE_MATRIX_URL_MATCH =
-  '/api/proxy/plugin/logging-view-plugin/backend/loki/api/v1/query_range?query=sum*';
+  '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application/loki/api/v1/query_range?query=sum*';
 const TEST_MESSAGE = "loki_1 | level=info msg='test log'";
 
 describe('Logs Page', () => {

--- a/logging-view-plugin-resources.yml
+++ b/logging-view-plugin-resources.yml
@@ -137,6 +137,22 @@ spec:
       alias: backend
       authorize: true
       service:
-        name: lokistack-dev-query-frontend-http
+        name: lokistack-sample-gateway-http
         namespace: openshift-logging
-        port: 3001
+        port: 8080
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logging-view-config
+  namespace: logging-view
+  labels:
+    app: logging-view-plugin
+    app.kubernetes.io/part-of: logging-view-plugin
+data:
+  config: |
+    {
+      "useTenantInHeader": true,
+      "isStreamingEnabledInDefaultPage": true
+    }

--- a/mockModules/dummy.tsx
+++ b/mockModules/dummy.tsx
@@ -1,8 +1,4 @@
 export { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 export { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/ws-factory';
 
-export class Dummy extends Error {
-  constructor() {
-    super('Dummy file for exports');
-  }
-}
+export const useK8sWatchResource = () => [null, true, ''];

--- a/scripts/image.sh
+++ b/scripts/image.sh
@@ -22,7 +22,7 @@ else
     OCI_BIN="docker"
 fi
 
-BASE_IMAGE="quay.io/gbernal/logging-view-plugin"
+BASE_IMAGE="quay.io/openshift-logging/logging-view-plugin"
 IMAGE=${BASE_IMAGE}:${TAG}
 
 echo "Building image '${IMAGE}' with ${OCI_BIN}"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,11 +26,9 @@ const App = () => {
                   </Link>
                 </li>
                 <li className="pf-c-nav__item">
-                  <a href="#" aria-current="page">
-                    <Link className="pf-c-nav__link" to="/monitoring/logs">
-                      Logs
-                    </Link>
-                  </a>
+                  <Link className="pf-c-nav__link" to="/monitoring/logs">
+                    Logs
+                  </Link>
                 </li>
               </ul>
             </nav>

--- a/src/logs.types.ts
+++ b/src/logs.types.ts
@@ -1,3 +1,8 @@
+export type Config = {
+  useTenantInHeader?: boolean;
+  isStreamingEnabledInDefaultPage?: boolean;
+};
+
 export type MetricValue = Array<number | string>;
 
 export type TimeRange = { start: number; end: number };

--- a/src/pages/logs-page.tsx
+++ b/src/pages/logs-page.tsx
@@ -13,13 +13,13 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router';
-import { TestIds } from '../test-ids';
 import { LogsHistogram } from '../components/logs-histogram';
 import { LogsQueryInput } from '../components/logs-query-input';
 import { LogsTable } from '../components/logs-table';
 import { useLogs } from '../hooks/useLogs';
 import { useQueryParams } from '../hooks/useQueryParams';
 import { isSeverity, Severity } from '../severity';
+import { TestIds } from '../test-ids';
 import { timeRangeOptions } from '../time-range-options';
 
 const DEFAULT_TIME_RANGE = '1h';
@@ -202,6 +202,7 @@ const LogsPage: React.FunctionComponent = () => {
     timeRange,
     interval,
     toggleStreaming,
+    config,
   } = useLogs();
 
   const handleToggleStreaming = () => {
@@ -311,7 +312,7 @@ const LogsPage: React.FunctionComponent = () => {
           isLoadingMore={isLoadingMoreLogsData}
           hasMoreLogsData={hasMoreLogsData}
           error={logsError}
-          showStreaming
+          showStreaming={config.isStreamingEnabledInDefaultPage}
         >
           <LogsQueryInput
             value={query}


### PR DESCRIPTION
Allow the plugin to read a ConfigMap that holds configuration on how to fetch data from loki, the default configuration is to use the LokiStack.