### PR TITLE
Fix severity dropdown sync on detail page

### DIFF
--- a/cypress/integration/logs-detail-page.cy.ts
+++ b/cypress/integration/logs-detail-page.cy.ts
@@ -1,0 +1,78 @@
+import { TestIds } from '../../src/test-ids';
+import { queryRangeStreamsvalidResponse } from '../fixtures/query-range-fixtures';
+
+const LOGS_DETAIL_PAGE_URL = '/k8s/ns/default/pods/test-pod-name';
+const QUERY_RANGE_STREAMS_URL_MATCH =
+  '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application/loki/api/v1/query_range?query=%7B*';
+const TEST_MESSAGE = "loki_1 | level=info msg='test log'";
+
+describe('Logs Detail Page', () => {
+  it('executes a query when "run query" is pressed', () => {
+    cy.intercept(
+      QUERY_RANGE_STREAMS_URL_MATCH,
+      queryRangeStreamsvalidResponse({ message: TEST_MESSAGE }),
+    ).as('queryRangeStreams');
+
+    cy.visit(LOGS_DETAIL_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsTable)
+      .should('exist')
+      .within(() => {
+        cy.contains(TEST_MESSAGE);
+      });
+
+    cy.getByTestId(TestIds.ExecuteQueryButton).click();
+
+    cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
+  });
+
+  it('executes a query with a new value when "Enter" is pressed on the query input field', () => {
+    cy.intercept(
+      QUERY_RANGE_STREAMS_URL_MATCH,
+      queryRangeStreamsvalidResponse({ message: TEST_MESSAGE }),
+    ).as('queryRangeStreams');
+
+    cy.visit(LOGS_DETAIL_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsTable)
+      .should('exist')
+      .within(() => {
+        cy.contains(TEST_MESSAGE);
+      });
+
+    cy.getByTestId(TestIds.LogsQueryInput).within(() => {
+      cy.get('input')
+        .type('{selectAll}')
+        .type('{ job = "some_job" }', {
+          parseSpecialCharSequences: false,
+          delay: 1,
+        })
+        .type('{enter}');
+    });
+
+    cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
+  });
+
+  it('executes a query with the severity is changed', () => {
+    cy.intercept(
+      QUERY_RANGE_STREAMS_URL_MATCH,
+      queryRangeStreamsvalidResponse({ message: TEST_MESSAGE }),
+    ).as('queryRangeStreams');
+
+    cy.visit(LOGS_DETAIL_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsTable)
+      .should('exist')
+      .within(() => {
+        cy.contains(TEST_MESSAGE);
+      });
+
+    cy.getByTestId(TestIds.SeverityDropdown)
+      .click()
+      .within(() => {
+        cy.contains('warning').click();
+      });
+
+    cy.get('@queryRangeStreams.all').should('have.length.at.least', 2);
+  });
+});

--- a/src/components/logs-toolbar.tsx
+++ b/src/components/logs-toolbar.tsx
@@ -18,6 +18,7 @@ import { Spacer } from './spacer';
 import { TenantDropdown } from './tenant-dropdown';
 import { TogglePlay } from './toggle-play';
 import './logs-toolbar.css';
+import { TestIds } from '../test-ids';
 
 interface LogsToolbarProps {
   query: string;
@@ -111,6 +112,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             deleteChipGroup={onDeleteSeverityGroup}
             categoryName="Severity"
             className="co-logs-severity-filter"
+            data-test={TestIds.SeverityDropdown}
           >
             <Select
               variant={SelectVariant.checkbox}

--- a/src/hooks/useLogs.ts
+++ b/src/hooks/useLogs.ts
@@ -367,17 +367,19 @@ export const useLogs = (
     query,
     severityFilter,
     tenant,
+    timeSpan,
   }: {
     query: string;
     severityFilter: Set<Severity>;
     tenant?: string;
+    timeSpan?: number;
   }) => {
     try {
       currentQuery.current = query;
       currentSeverityFilter.current = severityFilter;
       currentTenant.current = tenant ?? currentTenant.current;
 
-      const { start, end } = timeRangeFromSpan(localTimeSpan);
+      const { start, end } = timeRangeFromSpan(timeSpan ?? localTimeSpan);
 
       dispatch({ type: 'logsRequest' });
 
@@ -492,10 +494,12 @@ export const useLogs = (
     query,
     severityFilter,
     tenant,
+    timeSpan,
   }: {
     query: string;
     severityFilter: Set<Severity>;
     tenant?: string;
+    timeSpan?: number;
   }) => {
     try {
       currentQuery.current = query;
@@ -503,7 +507,7 @@ export const useLogs = (
       currentTenant.current = tenant ?? currentTenant.current;
 
       // TODO split on multiple/parallel queries for long timespans and concat results
-      const { start, end } = timeRangeFromSpan(localTimeSpan);
+      const { start, end } = timeRangeFromSpan(timeSpan ?? localTimeSpan);
 
       dispatch({ type: 'histogramRequest' });
 
@@ -541,10 +545,12 @@ export const useLogs = (
       getLogs({
         query: currentQuery.current,
         severityFilter: currentSeverityFilter.current,
+        timeSpan: localTimeSpan,
       });
       getHistogram({
         query: currentQuery.current,
         severityFilter: currentSeverityFilter.current,
+        timeSpan: localTimeSpan,
       });
     }
 

--- a/src/pages/logs-detail-page.tsx
+++ b/src/pages/logs-detail-page.tsx
@@ -37,13 +37,22 @@ const LogsDetailPage: React.FunctionComponent = () => {
     }
   };
 
-  const runQuery = () => {
-    getLogs({ query, severityFilter });
+  const runQuery = ({
+    severityFilterValue,
+  }: {
+    severityFilterValue?: Set<Severity>;
+  } = {}) => {
+    getLogs({ query, severityFilter: severityFilterValue ?? severityFilter });
   };
 
   React.useEffect(() => {
     runQuery();
   }, []);
+
+  const handleSeverityFilterChange = (severityFilterValue: Set<Severity>) => {
+    setSeverityFilter(severityFilterValue);
+    runQuery({ severityFilterValue });
+  };
 
   return (
     <PageSection>
@@ -62,12 +71,13 @@ const LogsDetailPage: React.FunctionComponent = () => {
             onQueryChange={setQuery}
             onQueryRun={runQuery}
             severityFilter={severityFilter}
-            onSeverityChange={setSeverityFilter}
+            onSeverityChange={handleSeverityFilterChange}
             isStreaming={isStreaming}
             onStreamingToggle={handleToggleStreaming}
             showResources={showResources}
             onShowResourcesToggle={setShowResources}
             enableStreaming
+            enableTenantDropdown={false}
           />
         </LogsTable>
       </Grid>

--- a/src/test-ids.ts
+++ b/src/test-ids.ts
@@ -7,4 +7,5 @@ export enum TestIds {
   LogsQueryInput = 'LogsQueryInput',
   ExecuteQueryButton = 'ExecuteQueryButton',
   TenantDropdown = 'TenantDropdown',
+  SeverityDropdown = 'SeverityDropdown',
 }


### PR DESCRIPTION
When selecting severity filter on the detail page the view was not updated until run query was pressed