### PR TITLE
Improve table message display

### DIFF
--- a/src/components/logs-table.tsx
+++ b/src/components/logs-table.tsx
@@ -93,7 +93,7 @@ const streamToTableData = (stream: StreamLogData): Array<LogTableData> => {
   const values = stream.values;
 
   return values.map((value) => {
-    const message = String(value[1]);
+    const message = String(stream.stream['message'] || value[1]);
     const timestamp = parseFloat(String(value[0]));
     const time = timestamp / 1e6;
     const formattedTime = dateToFormat(time, DateFormat.Full);


### PR DESCRIPTION
Use the message instead of the whole content to display log rows in the table

<img width="1469" alt="Screenshot 2022-09-21 at 09 41 33" src="https://user-images.githubusercontent.com/5461414/191444843-5c65c638-06db-4d2c-a778-2c311c2b36a9.png">
