### PR TITLE
Preselect tenant based in namespace on detail view

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,7 @@ const App = () => {
           <Route path="/dev-monitoring/ns/:ns/logs">
             <LogsDevPage />
           </Route>
-          <Route path="/k8s/ns/:namespace/pods/:name">
+          <Route path="/k8s/ns/:ns/pods/:name">
             <LogsDetailPage />
           </Route>
         </main>

--- a/src/pages/logs-page.tsx
+++ b/src/pages/logs-page.tsx
@@ -87,20 +87,24 @@ const LogsPage: React.FunctionComponent = () => {
     history.push(`${location.pathname}?${queryParams.toString()}`);
   };
 
-  const runQuery = (
-    queryToRun?: string,
-    severityToConsider?: Set<Severity>,
-    tenantToConsider?: string,
-  ) => {
+  const runQuery = ({
+    queryValue,
+    severityValue,
+    tenantValue,
+  }: {
+    queryValue?: string;
+    severityValue?: Set<Severity>;
+    tenantValue?: string;
+  } = {}) => {
     getLogs({
-      query: queryToRun ?? query,
-      severityFilter: severityToConsider ?? severityFilter,
-      tenant: tenantToConsider ?? tenant,
+      query: queryValue ?? query,
+      severityFilter: severityValue ?? severityFilter,
+      tenant: tenantValue ?? tenant,
     });
     getHistogram({
-      query: queryToRun ?? query,
-      severityFilter: severityToConsider ?? severityFilter,
-      tenant: tenantToConsider ?? tenant,
+      query: queryValue ?? query,
+      severityFilter: severityValue ?? severityFilter,
+      tenant: tenantValue ?? tenant,
     });
   };
 
@@ -111,17 +115,17 @@ const LogsPage: React.FunctionComponent = () => {
   React.useEffect(() => {
     return history.listen((location) => {
       const urlParams = new URLSearchParams(location.search);
-      const newQuery = urlParams.get(QUERY_PARAM_KEY) ?? DEFAULT_QUERY;
-      const newTenant = urlParams.get(TENANT_PARAM_KEY) ?? DEFAULT_TENANT;
-      const newSeverityFilter = severityFiltersFromParams(
+      const queryValue = urlParams.get(QUERY_PARAM_KEY) ?? DEFAULT_QUERY;
+      const tenantValue = urlParams.get(TENANT_PARAM_KEY) ?? DEFAULT_TENANT;
+      const severityValue = severityFiltersFromParams(
         urlParams.get(SEVERITY_FILTER_PARAM_KEY),
       );
 
-      setQuery(newQuery);
-      setTenant(newTenant);
-      setSeverityFilter(newSeverityFilter);
+      setQuery(queryValue);
+      setTenant(tenantValue);
+      setSeverityFilter(severityValue);
 
-      runQuery(newQuery, newSeverityFilter, newTenant);
+      runQuery({ queryValue, severityValue, tenantValue });
     });
   }, [history]);
 


### PR DESCRIPTION
A tenant will be preselected based on the namespace of the pod. This will allow users to see `infrastructure` logs for pods in `openshift`, `openshift-*`, `kube-*`, `default` namespaces

addresses https://issues.redhat.com/browse/LOG-2992