### PR TITLE
Do not display resources that are empty in the logs table

### DIFF
--- a/src/components/logs-table.tsx
+++ b/src/components/logs-table.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-table';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { notUndefined } from '../value-utils';
 import { DateFormat, dateToFormat } from '../date-utils';
 import {
   isStreamsResult,
@@ -73,20 +74,26 @@ type LogRowProps = {
 };
 
 const parseResources = (data: Record<string, string>): Array<Resource> => {
-  const container = {
-    kind: 'Container',
-    name: data['kubernetes_container_name'],
-  };
-  const namespace = {
-    kind: 'Namespace',
-    name: data['kubernetes_namespace_name'],
-  };
-  const pod = {
-    kind: 'Pod',
-    name: data['kubernetes_pod_name'],
-  };
+  const container = data['kubernetes_container_name']
+    ? {
+        kind: 'Container',
+        name: data['kubernetes_container_name'],
+      }
+    : undefined;
+  const namespace = data['kubernetes_namespace_name']
+    ? {
+        kind: 'Namespace',
+        name: data['kubernetes_namespace_name'],
+      }
+    : undefined;
+  const pod = data['kubernetes_pod_name']
+    ? {
+        kind: 'Pod',
+        name: data['kubernetes_pod_name'],
+      }
+    : undefined;
 
-  return [namespace, pod, container];
+  return [namespace, pod, container].filter(notUndefined);
 };
 
 const streamToTableData = (stream: StreamLogData): Array<LogTableData> => {

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -20,6 +20,9 @@ export const valueWithScalePrefix = (value: number): string => {
 export const notEmptyString = (value: string): value is string =>
   value.length > 0;
 
+export const notUndefined = <T>(value: T | undefined): value is T =>
+  value !== undefined;
+
 const s = 1000;
 const m = s * 60;
 const h = m * 60;


### PR DESCRIPTION
If the log does not contain k8s resources do not display them

<img width="1464" alt="Screenshot 2022-09-21 at 12 20 19" src="https://user-images.githubusercontent.com/5461414/191480135-ec36aaa2-7335-40f4-8b36-47b1f4248b03.png">
