### PR TITLE
update Dropdown time when selecting a range in the histogram

### DIFF
--- a/src/pages/logs-dev-page.tsx
+++ b/src/pages/logs-dev-page.tsx
@@ -97,17 +97,23 @@ const LogsDevPage: React.FunctionComponent = () => {
     runQuery();
   }, [timeRange, isHistogramVisible, namespace]);
 
+  const isQueryEmpty = query === '';
+
   return (
     <PageSection>
       <Grid hasGutter>
-        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
           <Flex>
             <ToggleHistogramButton
               isToggled={isHistogramVisible}
               onToggle={() => setIsHistogramVisible(!isHistogramVisible)}
               data-test={TestIds.ToggleHistogramButton}
             />
-            <TimeRangeDropdown onChange={setTimeRangeInURL} />
+            <TimeRangeDropdown
+              value={timeRange}
+              onChange={setTimeRangeInURL}
+              isDisabled={isQueryEmpty}
+            />
             <RefreshIntervalDropdown onRefresh={runQuery} />
             <Tooltip content={<div>Refresh</div>}>
               <Button
@@ -115,6 +121,7 @@ const LogsDevPage: React.FunctionComponent = () => {
                 aria-label="Refresh"
                 variant="primary"
                 data-test={TestIds.SyncButton}
+                isDisabled={isQueryEmpty}
               >
                 <SyncAltIcon />
               </Button>
@@ -153,6 +160,7 @@ const LogsDevPage: React.FunctionComponent = () => {
             showResources={areResourcesShown}
             onShowResourcesToggle={setShowResourcesInURL}
             enableTenantDropdown={false}
+            isDisabled={isQueryEmpty}
             attributeList={availableDevConsoleAttributes}
             filters={filters}
             onFiltersChange={handleFiltersChange}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/LOG-3424

This PR includes the following adjustments for the dev console logs:
- Update the time range selection on the dropdown when is selected on the histogram
- Disable controls when the query is empty
- Adjust histogram and time range selector horizontal alignment

https://user-images.githubusercontent.com/5461414/207318812-17f3e476-fa4b-4eca-883f-f8d3e7ef112c.mov

