### PR TITLE
Improve histogram display for sub second time resolution

### DIFF
--- a/cypress/integration/logs-page.cy.ts
+++ b/cypress/integration/logs-page.cy.ts
@@ -6,6 +6,7 @@ import {
   queryRangeStreamsValidResponse,
 } from '../fixtures/query-range-fixtures';
 import { namespaceListResponse } from '../fixtures/resource-api-fixtures';
+import { formatTimeRange } from '../../src/time-range';
 
 const LOGS_PAGE_URL = '/monitoring/logs';
 const QUERY_RANGE_STREAMS_URL_MATCH =
@@ -367,7 +368,7 @@ describe('Logs Page', () => {
     cy.get('@resourceQuery.all').should('have.length.at.least', 1);
   });
 
-  it('updates the url with the proper parameters when selecting a custom range', () => {
+  it.only('updates the url with the proper parameters when selecting a custom range', () => {
     cy.intercept(
       QUERY_RANGE_STREAMS_URL_MATCH,
       queryRangeStreamsValidResponse({ message: TEST_MESSAGE }),
@@ -409,7 +410,9 @@ describe('Logs Page', () => {
 
     cy.url().should('match', new RegExp(`start=${startTime}&end=${endTime}`));
 
-    cy.contains('2022-10-17 14:50 - 2022-10-17 15:55');
+    const formattedTimeRange = formatTimeRange({ start: startTime, end: endTime });
+
+    cy.contains(formattedTimeRange);
 
     cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
     cy.get('@queryRangeMatrix.all').should('have.length.at.least', 1);

--- a/src/components/time-range-select-modal.tsx
+++ b/src/components/time-range-select-modal.tsx
@@ -8,10 +8,11 @@ import {
   TimePicker,
 } from '@patternfly/react-core';
 import React from 'react';
+import { DateFormat, dateToFormat } from '../date-utils';
 import { TimeRange } from '../logs.types';
 import { TestIds } from '../test-ids';
 import { defaultTimeRange, numericTimeRange } from '../time-range';
-import { formatDate, formatTime, padLeadingZero } from '../value-utils';
+import { padLeadingZero } from '../value-utils';
 import './time-range-select-modal.css';
 
 interface TimeRangeSelectModal {
@@ -28,10 +29,18 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
   initialRange,
 }) => {
   const initialRangeNumber = numericTimeRange(initialRange ?? defaultTimeRange());
-  const [startDate, setStartDate] = React.useState<string>(formatDate(initialRangeNumber.start));
-  const [startTime, setStartTime] = React.useState<string>(formatTime(initialRangeNumber.start));
-  const [endDate, setEndDate] = React.useState<string>(formatDate(initialRangeNumber.end));
-  const [endTime, setEndTime] = React.useState<string>(formatTime(initialRangeNumber.end));
+  const [startDate, setStartDate] = React.useState<string>(
+    dateToFormat(initialRangeNumber.start, DateFormat.DateMed),
+  );
+  const [startTime, setStartTime] = React.useState<string>(
+    dateToFormat(initialRangeNumber.start, DateFormat.TimeFull),
+  );
+  const [endDate, setEndDate] = React.useState<string>(
+    dateToFormat(initialRangeNumber.end, DateFormat.DateMed),
+  );
+  const [endTime, setEndTime] = React.useState<string>(
+    dateToFormat(initialRangeNumber.end, DateFormat.TimeFull),
+  );
   const [isRangeValid, setIsRangeValid] = React.useState(false);
 
   const isRangeSelected = startDate && startTime && endDate && endTime;

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,6 +1,10 @@
+import { TimeRangeNumber } from './logs.types';
+
 export enum DateFormat {
   TimeShort,
   TimeMed,
+  TimeFull,
+  DateMed,
   Full,
 }
 
@@ -19,10 +23,22 @@ export const timeShortFormatter = new Intl.DateTimeFormat(undefined, {
 });
 
 export const timeMedFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: 'numeric',
+  hour: '2-digit',
+  hourCycle: 'h24',
+  minute: '2-digit',
   second: 'numeric',
 });
+
+const dateMedFormatter = new Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+const getPart = (
+  parts: Intl.DateTimeFormatPart[],
+  type: 'day' | 'hour' | 'minute' | 'month' | 'second' | 'year',
+) => parts.find((p) => p.type === type)?.value || '';
 
 export const dateToFormat = (date: Date | number, format: DateFormat): string => {
   switch (format) {
@@ -32,6 +48,15 @@ export const dateToFormat = (date: Date | number, format: DateFormat): string =>
     case DateFormat.TimeMed:
       return timeMedFormatter.format(date);
       break;
+    case DateFormat.DateMed: {
+      const parts = dateMedFormatter.formatToParts(date);
+      return `${getPart(parts, 'year')}-${getPart(parts, 'month')}-${getPart(parts, 'day')}`;
+    }
+    case DateFormat.TimeFull: {
+      const fractionalSeconds =
+        typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
+      return `${timeMedFormatter.format(date)}.${fractionalSeconds}`;
+    }
     case DateFormat.Full:
       {
         const fractionalSeconds =
@@ -40,4 +65,17 @@ export const dateToFormat = (date: Date | number, format: DateFormat): string =>
       }
       break;
   }
+};
+
+export const getTimeFormatFromTimeRange = (timeRange: TimeRangeNumber): DateFormat =>
+  getTimeFormatFromInterval(timeRange.end - timeRange.start);
+
+export const getTimeFormatFromInterval = (interval: number): DateFormat => {
+  if (interval <= 60 * 1000) {
+    return DateFormat.TimeFull;
+  } else if (interval < 30 * 60 * 1000) {
+    return DateFormat.TimeMed;
+  }
+
+  return DateFormat.TimeShort;
 };

--- a/src/time-range.ts
+++ b/src/time-range.ts
@@ -1,5 +1,6 @@
+import { DateFormat, dateToFormat, getTimeFormatFromTimeRange } from './date-utils';
 import { TimeRange, timeRangeIsNumber, timeRangeIsText, TimeRangeNumber } from './logs.types';
-import { formatDate, formatTime, millisecondsFromDuration, units } from './value-utils';
+import { millisecondsFromDuration, units } from './value-utils';
 
 export const CUSTOM_TIME_RANGE_KEY = 'CUSTOM';
 
@@ -122,8 +123,16 @@ export const intervalFromTimeRange = (
 
 export const formatTimeRange = (timeRange: TimeRange): string => {
   const numericRange = numericTimeRange(timeRange);
-  const start = `${formatDate(numericRange.start)} ${formatTime(numericRange.start)}`;
-  const end = `${formatDate(numericRange.end)} ${formatTime(numericRange.end)}`;
+  const timeFormat = getTimeFormatFromTimeRange(numericRange);
+
+  const start = `${dateToFormat(numericRange.start, DateFormat.DateMed)} ${dateToFormat(
+    numericRange.start,
+    timeFormat,
+  )}`;
+  const end = `${dateToFormat(numericRange.end, DateFormat.DateMed)} ${dateToFormat(
+    numericRange.end,
+    timeFormat,
+  )}`;
 
   return `${start} - ${end}`;
 };

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -66,30 +66,4 @@ export const millisecondsFromDuration = (duration: string): number => {
   }
 };
 
-const getPart = (
-  parts: Intl.DateTimeFormatPart[],
-  type: 'day' | 'hour' | 'minute' | 'month' | 'second' | 'year',
-) => parts.find((p) => p.type === type)?.value || '';
-
-export const formatDate = (timestamp: number): string => {
-  const parts = new Intl.DateTimeFormat('en', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(timestamp);
-  return `${getPart(parts, 'year')}-${getPart(parts, 'month')}-${getPart(parts, 'day')}`;
-};
-export const formatTime = (timestamp: number, includeSeconds = false): string => {
-  const parts = new Intl.DateTimeFormat('en', {
-    hour: '2-digit',
-    hourCycle: 'h24',
-    minute: '2-digit',
-    second: 'numeric',
-  }).formatToParts(timestamp);
-  const seconds = includeSeconds ? `:${getPart(parts, 'second')}` : '';
-  return `${getPart(parts, 'hour')}:${getPart(parts, 'minute')}${seconds}`;
-};
-
-export const trim = (value: string): string => value.trim();
-
 export const padLeadingZero = (value: number) => (value > 9 ? value : `0${value}`);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/LOG-3384

this PR fixes the histogram bars not displaying for sub-second time ranges, also:
- Refactors time formatting centralizing time related functions in `date-utils`
- Disables selecting the same start and end dates when using the mouse to select a range in the histogram