### PR TITLE
Add precision time picker for time range modal

### DIFF
--- a/cypress/integration/logs-page.cy.ts
+++ b/cypress/integration/logs-page.cy.ts
@@ -368,7 +368,7 @@ describe('Logs Page', () => {
     cy.get('@resourceQuery.all').should('have.length.at.least', 1);
   });
 
-  it.only('updates the url with the proper parameters when selecting a custom range', () => {
+  it('updates the url with the proper parameters when selecting a custom range', () => {
     cy.intercept(
       QUERY_RANGE_STREAMS_URL_MATCH,
       queryRangeStreamsValidResponse({ message: TEST_MESSAGE }),
@@ -399,8 +399,8 @@ describe('Logs Page', () => {
       cy.get('input[aria-label="Date picker"]').first().clear().type('2022-10-17').blur();
       cy.get('input[aria-label="Date picker"]').last().clear().type('2022-10-17').blur();
 
-      cy.get('input[aria-label="Time picker"]').first().clear().type('14:50{enter}');
-      cy.get('input[aria-label="Time picker"]').last().clear().type('15:55{enter}');
+      cy.get('input[aria-label="Precision time picker"]').first().clear().type('14:50{enter}');
+      cy.get('input[aria-label="Precision time picker"]').last().clear().type('15:55{enter}');
     });
 
     cy.getByTestId(TestIds.TimeRangeDropdownSaveButton).click();

--- a/src/components/precision-time-picker.css
+++ b/src/components/precision-time-picker.css
@@ -1,0 +1,12 @@
+.co-logs-time-picker__time-options {
+  max-height: 200px;
+  overflow: auto;
+}
+
+.co-logs-time-picker__input {
+  width: 150px;
+}
+
+.co-logs-time-picker__error {
+  padding-top: 'var(--pf-global--spacer--xs)';
+}

--- a/src/components/precision-time-picker.tsx
+++ b/src/components/precision-time-picker.tsx
@@ -1,0 +1,147 @@
+import {
+  HelperText,
+  HelperTextItem,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  Popper,
+  TextInput,
+  ValidatedOptions,
+} from '@patternfly/react-core';
+import React from 'react';
+import { useBoolean } from '../hooks/useBoolean';
+import { padLeadingZero } from '../value-utils';
+import './precision-time-picker.css';
+
+interface PrecisionTimePickerProps {
+  time: string;
+  onChange?: (time: string, hours?: number, minutes?: number, seconds?: number) => void;
+}
+
+const validTimeStringRegex = /^\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/;
+
+const parseTimeString = (
+  time: string,
+): { hours: number; minutes: number; seconds: number } | null => {
+  if (!validTimeStringRegex.test(time)) {
+    return null;
+  }
+
+  const parts = time.split(':');
+
+  if (parts.length >= 2) {
+    let hours = parseInt(parts[0], 10);
+    hours = hours >= 24 ? 0 : hours;
+    const minutes = parseInt(parts[1], 10);
+    const seconds = parts.length >= 3 ? parseFloat(parts[2]) : 0;
+
+    if (!isNaN(hours) && !isNaN(minutes) && !isNaN(seconds)) {
+      return { hours, minutes, seconds };
+    }
+  }
+
+  return null;
+};
+
+const timeMenuItemsBuilder: () => Array<string> = () => {
+  const items = [];
+
+  for (let hours = 0; hours < 24; hours++) {
+    for (let minutes = 0; minutes < 60; minutes += 30) {
+      items.push(`${padLeadingZero(hours)}:${padLeadingZero(minutes)}`);
+    }
+  }
+
+  return items;
+};
+
+const timeMenuItems = timeMenuItemsBuilder();
+
+export const PrecisionTimePicker: React.FC<PrecisionTimePickerProps> = ({ onChange, time }) => {
+  const [value, setValue] = React.useState(time);
+  const [isValid, setIsvalid] = React.useState(true);
+  const { value: isMenuOpen, setTrue: openMenu, setFalse: closeMenu } = useBoolean(false);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const menuRef = React.useRef<HTMLDivElement | null>(null);
+
+  const handleValueChange = (changedValue: string) => {
+    setValue(changedValue);
+    const parsedTime = parseTimeString(changedValue);
+
+    if (parsedTime) {
+      setIsvalid(true);
+      onChange?.(changedValue, parsedTime.hours, parsedTime.minutes, parsedTime.seconds);
+    } else {
+      setIsvalid(false);
+      onChange?.(changedValue, undefined, undefined, undefined);
+    }
+
+    closeMenu();
+  };
+
+  const onDocumentClick = (event: MouseEvent | undefined) => {
+    if (
+      inputRef.current !== event?.target &&
+      !menuRef.current?.contains(event?.target as HTMLElement)
+    ) {
+      closeMenu();
+    }
+  };
+
+  const handleMenuSelect = (_?: React.MouseEvent, itemId?: string | number) => {
+    if (itemId && typeof itemId === 'string') {
+      handleValueChange(itemId);
+    }
+  };
+
+  const popper = (
+    <Menu
+      id="time-select-menu"
+      onSelect={handleMenuSelect}
+      className="co-logs-time-picker__time-options"
+      ref={menuRef}
+    >
+      <MenuContent>
+        <MenuList>
+          {timeMenuItems.map((item, index) => (
+            <MenuItem key={index} onClick={() => handleValueChange(item)} ref={null} itemID={item}>
+              {item}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const trigger = (
+    <div>
+      <TextInput
+        value={value}
+        onFocus={openMenu}
+        type="text"
+        iconVariant="clock"
+        onChange={handleValueChange}
+        aria-label="Precision time picker"
+        isRequired
+        validated={isValid ? undefined : ValidatedOptions.error}
+        className="co-logs-time-picker__input"
+        ref={inputRef}
+      />
+      {!isValid && (
+        <HelperText className="co-logs-time-picker__error">
+          <HelperTextItem variant="error">Invalid time format</HelperTextItem>
+        </HelperText>
+      )}
+    </div>
+  );
+
+  return (
+    <Popper
+      trigger={trigger}
+      popper={popper}
+      isVisible={isMenuOpen}
+      onDocumentClick={onDocumentClick}
+    />
+  );
+};

--- a/src/components/time-range-select-modal.tsx
+++ b/src/components/time-range-select-modal.tsx
@@ -5,7 +5,6 @@ import {
   Modal,
   ModalBoxBody,
   ModalVariant,
-  TimePicker,
 } from '@patternfly/react-core';
 import React from 'react';
 import { DateFormat, dateToFormat } from '../date-utils';
@@ -13,6 +12,7 @@ import { TimeRange } from '../logs.types';
 import { TestIds } from '../test-ids';
 import { defaultTimeRange, numericTimeRange } from '../time-range';
 import { padLeadingZero } from '../value-utils';
+import { PrecisionTimePicker } from './precision-time-picker';
 import './time-range-select-modal.css';
 
 interface TimeRangeSelectModal {
@@ -47,8 +47,8 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
 
   React.useEffect(() => {
     if (isRangeSelected) {
-      const start = `${startDate}T${startTime}:00`;
-      const end = `${endDate}T${endTime}:00`;
+      const start = `${startDate}T${startTime}`;
+      const end = `${endDate}T${endTime}`;
 
       setIsRangeValid(Date.parse(start) < Date.parse(end));
     } else {
@@ -58,21 +58,52 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
 
   const handleSelectRange = () => {
     if (isRangeSelected) {
-      const start = `${startDate}T${startTime}:00`;
-      const end = `${endDate}T${endTime}:00`;
+      const start = `${startDate}T${startTime}`;
+      const end = `${endDate}T${endTime}`;
 
       onSelectRange?.({ start: Date.parse(start), end: Date.parse(end) });
     }
   };
 
-  const handleStartTimeChange = (_time: string, hour?: number, minute?: number) => {
-    if (hour !== undefined && hour !== null && minute !== undefined && minute !== null) {
-      setStartTime(`${padLeadingZero(hour)}:${padLeadingZero(minute)}`);
+  const handleStartTimeChange = (
+    _time: string,
+    hours?: number,
+    minutes?: number,
+    seconds?: number,
+  ) => {
+    if (
+      hours !== undefined &&
+      hours !== null &&
+      minutes !== undefined &&
+      minutes !== null &&
+      seconds !== undefined &&
+      seconds !== null
+    ) {
+      setStartTime(
+        `${padLeadingZero(hours)}:${padLeadingZero(minutes)}:${padLeadingZero(seconds)}`,
+      );
+    } else {
+      setIsRangeValid(false);
     }
   };
-  const handleEndTimeChange = (_time: string, hour?: number, minute?: number) => {
-    if (hour !== undefined && hour !== null && minute !== undefined && minute !== null) {
-      setEndTime(`${padLeadingZero(hour)}:${padLeadingZero(minute)}`);
+
+  const handleEndTimeChange = (
+    _time: string,
+    hour?: number,
+    minutes?: number,
+    seconds?: number,
+  ) => {
+    if (
+      hour !== undefined &&
+      hour !== null &&
+      minutes !== undefined &&
+      minutes !== null &&
+      seconds !== undefined &&
+      seconds !== null
+    ) {
+      setEndTime(`${padLeadingZero(hour)}:${padLeadingZero(minutes)}:${padLeadingZero(seconds)}`);
+    } else {
+      setIsRangeValid(false);
     }
   };
 
@@ -88,6 +119,7 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
       onClose={onClose}
       showClose={false}
       hasNoBodyWrapper={true}
+      aria-label="date-time-picker-modal"
       data-test={TestIds.TimeRangeSelectModal}
       footer={
         <div className="co-logs-time-range-modal__footer">
@@ -114,24 +146,14 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
           <label>From</label>
           <div className="co-logs-time-range-modal__field">
             <DatePicker onChange={setStartDate} value={startDate} />
-            <TimePicker
-              menuAppendTo="inline"
-              is24Hour
-              onChange={handleStartTimeChange}
-              time={startTime}
-            />
+            <PrecisionTimePicker time={startTime} onChange={handleStartTimeChange} />
           </div>
         </div>
         <div>
           <label>To</label>
           <div className="co-logs-time-range-modal__field">
             <DatePicker onChange={setEndDate} value={endDate} />
-            <TimePicker
-              menuAppendTo="inline"
-              is24Hour
-              onChange={handleEndTimeChange}
-              time={endTime}
-            />
+            <PrecisionTimePicker time={endTime} onChange={handleEndTimeChange} />
           </div>
           {!isRangeValid && (
             <Alert

--- a/src/hooks/useBoolean.ts
+++ b/src/hooks/useBoolean.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface UseBooleanOutput {
+  value: boolean;
+  setValue: React.Dispatch<React.SetStateAction<boolean>>;
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+}
+
+export const useBoolean = (defaultValue?: boolean): UseBooleanOutput => {
+  const [value, setValue] = React.useState(!!defaultValue);
+
+  const setTrue = React.useCallback(() => setValue(true), []);
+  const setFalse = React.useCallback(() => setValue(false), []);
+  const toggle = React.useCallback(() => setValue((x) => !x), []);
+
+  return { value, setValue, setTrue, setFalse, toggle };
+};

--- a/src/value-utils.ts
+++ b/src/value-utils.ts
@@ -66,7 +66,8 @@ export const millisecondsFromDuration = (duration: string): number => {
   }
 };
 
-export const padLeadingZero = (value: number) => (value > 9 ? value : `0${value}`);
+export const padLeadingZero = (value: number): string =>
+  value >= 10 ? value.toString(10) : `0${value}`;
 
 const DEFAULT_TENANT = 'application';
 


### PR DESCRIPTION
This PR adds a new component that can handle sub-second resolution when selecting a time range.

Fixes: https://issues.redhat.com/browse/LOG-3384

https://user-images.githubusercontent.com/5461414/213389159-3ec1bf44-1c3c-4fb0-801c-1fb0d740cd2e.mov

