### PR TITLE
Add logs based alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ web/.nyc_output/
 .DS_Store
 /plugin-backend
 env.list
+.vscode

--- a/config/alerts.patch.json
+++ b/config/alerts.patch.json
@@ -1,0 +1,26 @@
+[
+  {
+    "op": "add",
+    "path": "/extensions/0",
+    "value": {
+      "type": "console.alerts/rules-source",
+      "properties": {
+        "id": "logging-loki",
+        "contextId": "observe-alerting",
+        "getAlertingRules": { "$codeRef": "getAlertingRules" }
+      }
+    }
+  },
+
+  {
+    "op": "add",
+    "path": "/extensions/0",
+    "value": {
+      "type": "console.alerts/rules-chart",
+      "properties": {
+        "sourceId": "logging-loki",
+        "chart": { "$codeRef": "LogsAlertMetrics" }
+      }
+    }
+  }
+]

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -47,5 +47,20 @@
       "contextId": "alert-detail-toolbar-actions",
       "provider": { "$codeRef": "LogActionsProvider" }
     }
+  },
+  {
+    "type": "console.alerts/rules-source",
+    "properties": {
+      "id": "logging-loki",
+      "contextId": "observe-alerting",
+      "getAlertingRules": { "$codeRef": "getAlertingRules" }
+    }
+  },
+  {
+    "type": "console.alerts/rules-chart",
+    "properties": {
+      "sourceId": "logging-loki",
+      "chart": { "$codeRef": "LogsAlertMetrics" }
+    }
   }
 ]

--- a/web/cypress/integration/logs-alerts.cy.ts
+++ b/web/cypress/integration/logs-alerts.cy.ts
@@ -1,0 +1,66 @@
+import { TestIds } from '../../src/test-ids';
+import {
+  queryRangeMatrixInvalidResponse,
+  queryRangeMatrixValidResponse,
+} from '../fixtures/query-range-fixtures';
+
+const LOGS_ALERTS_PAGE_URL = '/monitoring/alerts/test-alert';
+const QUERY_RANGE_MATRIX_URL_MATCH =
+  '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application/loki/api/v1/query_range?query=sum*';
+
+describe('Alerts logs metrics', () => {
+  it('renders correctly with an expected response', () => {
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse());
+
+    cy.visit(LOGS_ALERTS_PAGE_URL);
+
+    cy.getByTestId(TestIds.TimeRangeDropdown).should('exist');
+
+    cy.getByTestId(TestIds.LogsMetrics)
+      .should('exist')
+      .within(() => {
+        cy.get('svg g > path').should('have.length.above', 0);
+      });
+  });
+
+  it('handles errors gracefully when a request fails', () => {
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, (req) => {
+      req.continue((res) => res.send({ statusCode: 500, body: 'Internal Server Error' }));
+    });
+
+    cy.visit(LOGS_ALERTS_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsMetrics)
+      .should('exist')
+      .within(() => {
+        cy.contains('Internal Server Error');
+      });
+  });
+
+  it('handles errors gracefully when a response is invalid', () => {
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixInvalidResponse());
+
+    cy.visit(LOGS_ALERTS_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsMetrics)
+      .should('exist')
+      .within(() => {
+        cy.contains('Unexpected end of JSON input');
+      });
+  });
+
+  it('executes a new query when a new time range is selected', () => {
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse()).as(
+      'queryRangeMatrix',
+    );
+
+    cy.visit(LOGS_ALERTS_PAGE_URL);
+
+    cy.getByTestId(TestIds.TimeRangeDropdown).within(() => {
+      cy.contains('Last 1 hour').click();
+      cy.contains('Last 6 hours').click();
+    });
+
+    cy.get('@queryRangeMatrix.all').should('have.length.at.least', 2);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -87,7 +87,9 @@
       "LogsPage": "./pages/logs-page",
       "LogsDetailPage": "./pages/logs-detail-page",
       "LogActionsProvider": "./hooks/useLogActionsExtension",
-      "LogsDevPage": "./pages/logs-dev-page"
+      "LogsDevPage": "./pages/logs-dev-page",
+      "getAlertingRules": "./getAlertingRules",
+      "LogsAlertMetrics": "./components/alerts/logs-alerts-metrics"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/web/src/components/alerts/logs-alerts-metrics.css
+++ b/web/src/components/alerts/logs-alerts-metrics.css
@@ -1,0 +1,13 @@
+.co-logs-alert-metrics__container {
+  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+  margin: 0 0 var(--pf-global--spacer--md) 0;
+  padding: var(--pf-global--spacer--sm);
+}
+
+.co-logs-metrics__header {
+  margin-bottom: var(--pf-global--spacer--sm);
+}
+
+.co-logs-metrics__error {
+  min-height: 250px;
+}

--- a/web/src/components/alerts/logs-alerts-metrics.tsx
+++ b/web/src/components/alerts/logs-alerts-metrics.tsx
@@ -1,0 +1,55 @@
+import { Alert } from '@patternfly/react-core';
+import React, { useEffect } from 'react';
+import { useLogs } from '../../hooks/useLogs';
+import { Rule, TimeRange } from '../../logs.types';
+import { CenteredContainer } from '../centered-container';
+import { LogsMetrics } from '../logs-metrics';
+import { TimeRangeDropdown } from '../time-range-dropdown';
+import './logs-alerts-metrics.css';
+
+interface LogsAlertMetricsProps {
+  rule?: Rule;
+}
+
+const LOKI_TENANT_LABEL_KEY = 'tenantId';
+
+const LogsAlertMetrics: React.FC<LogsAlertMetricsProps> = ({ rule }) => {
+  const { getLogs, logsData, logsError, isLoadingLogsData, config } = useLogs();
+
+  const tenant = rule?.labels?.[config.lokiTenanLabelKey ?? LOKI_TENANT_LABEL_KEY];
+  const [timeRange, setTimeRange] = React.useState<TimeRange | undefined>();
+
+  useEffect(() => {
+    if (rule?.query && tenant) {
+      getLogs({ query: rule.query, timeRange, tenant });
+    }
+  }, [rule?.query, timeRange]);
+
+  return (
+    <div className="co-logs-alert-metrics__container">
+      <div className="co-logs-metrics__header">
+        <TimeRangeDropdown value={timeRange} onChange={setTimeRange} />
+      </div>
+      {tenant ? (
+        <LogsMetrics
+          logsData={logsData}
+          error={logsError}
+          isLoading={isLoadingLogsData}
+          timeRange={timeRange}
+        />
+      ) : (
+        <CenteredContainer>
+          <Alert
+            className="co-logs-metrics__error"
+            variant="danger"
+            isInline
+            isPlain
+            title={`label '${LOKI_TENANT_LABEL_KEY} is required to display the alert metrics`}
+          />
+        </CenteredContainer>
+      )}
+    </div>
+  );
+};
+
+export default LogsAlertMetrics;

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -1,0 +1,168 @@
+import {
+  Chart,
+  ChartAxis,
+  ChartGroup,
+  ChartLegendTooltip,
+  ChartLine,
+  ChartThemeColor,
+  createContainer,
+} from '@patternfly/react-charts';
+import { Alert } from '@patternfly/react-core';
+import React from 'react';
+import { DateFormat, dateToFormat, getTimeFormatFromTimeRange } from '../date-utils';
+import { useRefWidth } from '../hooks/useRefWidth';
+import { isMatrixResult, QueryRangeResponse, TimeRange } from '../logs.types';
+import { TestIds } from '../test-ids';
+import { intervalFromTimeRange, numericTimeRange } from '../time-range';
+import { CenteredContainer } from './centered-container';
+
+type MetricsData = { name: string; data: Array<{ name: string; x: number; y: number }> };
+type Domain = [number, number];
+interface LogsMetricsProps {
+  logsData?: QueryRangeResponse;
+  timeRange?: TimeRange;
+  isLoading?: boolean;
+  error?: unknown;
+}
+
+const GRAPH_HEIGHT = 250;
+
+const matrixToMetricsData = (
+  response?: QueryRangeResponse,
+): { data: Array<MetricsData> | undefined; xDomain: Domain; yDomain: Domain } => {
+  if (!response) {
+    return { data: undefined, xDomain: [0, 1], yDomain: [0, 1] };
+  }
+
+  if (!isMatrixResult(response.data)) {
+    return { data: undefined, xDomain: [0, 1], yDomain: [0, 1] };
+  }
+
+  const values = response.data.result;
+  const xDomain: Domain = [Number.MAX_VALUE, Number.MIN_VALUE];
+  const yDomain: Domain = [Number.MAX_VALUE, Number.MIN_VALUE];
+
+  const data = values.map((value) => {
+    const seriesName = JSON.stringify(value.metric);
+
+    return {
+      name: seriesName,
+      data: value.values.map((coordinate) => {
+        const time = parseInt(String(coordinate[0])) * 1000;
+
+        if (time < xDomain[0]) {
+          xDomain[0] = time;
+        }
+        if (time > xDomain[1]) {
+          xDomain[1] = time;
+        }
+
+        const y = parseFloat(String(coordinate[1]));
+
+        if (y < yDomain[0]) {
+          yDomain[0] = y;
+        }
+        if (y > yDomain[1]) {
+          yDomain[1] = y;
+        }
+
+        return { x: time, y, name: seriesName };
+      }),
+    };
+  });
+
+  return { data, xDomain, yDomain };
+};
+
+const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+
+export const LogsMetrics: React.FC<LogsMetricsProps> = ({
+  logsData,
+  isLoading,
+  error,
+  timeRange,
+}) => {
+  const [containerRef, width] = useRefWidth();
+  const [timeRangeValue, setTimeRangeValue] = React.useState(numericTimeRange(timeRange));
+  const { data, xDomain, yDomain } = React.useMemo(() => matrixToMetricsData(logsData), [logsData]);
+
+  React.useEffect(() => {
+    setTimeRangeValue(numericTimeRange(timeRange));
+  }, [timeRange]);
+
+  const legendData = data?.map((series) => ({ childName: series.name, name: series.name }));
+  const intervalValue = intervalFromTimeRange(timeRangeValue);
+
+  return (
+    <div ref={containerRef} style={{ height: GRAPH_HEIGHT }} data-test={TestIds.LogsMetrics}>
+      {error ? (
+        <CenteredContainer>
+          <Alert
+            variant="danger"
+            isInline
+            isPlain
+            title={(error as Error).message || String(error)}
+          />
+        </CenteredContainer>
+      ) : isLoading ? (
+        <CenteredContainer>Loading...</CenteredContainer>
+      ) : data ? (
+        <Chart
+          containerComponent={
+            <CursorVoronoiContainer
+              cursorDimension="x"
+              activateData={false}
+              labels={({ datum }: { datum: { y: number } }) => datum.y}
+              labelComponent={
+                <ChartLegendTooltip
+                  legendData={legendData}
+                  title={(datum: { x: number }) =>
+                    dateToFormat(datum.x, getTimeFormatFromTimeRange(timeRangeValue))
+                  }
+                />
+              }
+              constrainToVisibleArea
+              mouseFollowTooltips
+              voronoiPadding={0}
+            />
+          }
+          legendData={data.map((series) => ({ name: series.name }))}
+          height={GRAPH_HEIGHT}
+          width={width}
+          name="alert metrics"
+          scale={{ x: 'time', y: 'linear' }}
+          themeColor={ChartThemeColor.multiUnordered}
+          padding={{
+            bottom: 40,
+            left: 65,
+            right: 10,
+            top: 10,
+          }}
+          domainPadding={{ x: [30, 25] }}
+          domain={{ x: xDomain, y: yDomain }}
+        >
+          <ChartAxis
+            tickCount={60}
+            fixLabelOverlap
+            tickFormat={(tick: number) =>
+              dateToFormat(
+                tick,
+                intervalValue < 60 * 1000 ? DateFormat.TimeMed : DateFormat.TimeShort,
+              )
+            }
+          />
+          <ChartAxis dependentAxis showGrid />
+          <ChartGroup>
+            {data.map((series) => (
+              <ChartLine name={series.name} key={series.name} data={series.data} />
+            ))}
+          </ChartGroup>
+        </Chart>
+      ) : (
+        <CenteredContainer>
+          <Alert variant="danger" isInline isPlain title="Invalid data" />
+        </CenteredContainer>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/tenant-dropdown.tsx
+++ b/web/src/components/tenant-dropdown.tsx
@@ -1,5 +1,6 @@
 import { OptionsMenu, OptionsMenuItem, OptionsMenuToggle } from '@patternfly/react-core';
 import React from 'react';
+import { TENANTS } from '../tenants';
 import { TestIds } from '../test-ids';
 
 interface TenantDropdownProps {
@@ -7,8 +8,6 @@ interface TenantDropdownProps {
   onTenantSelected?: (tenant: string) => void;
   isDisabled?: boolean;
 }
-
-const tenants = ['application', 'infrastructure', 'audit'];
 
 export const TenantDropdown: React.FC<TenantDropdownProps> = ({
   selectedTenant,
@@ -31,7 +30,7 @@ export const TenantDropdown: React.FC<TenantDropdownProps> = ({
       id="logging-view-tenant-dropdown"
       data-test={TestIds.TenantDropdown}
       disabled={isDisabled}
-      menuItems={tenants.map((tenant) => (
+      menuItems={TENANTS.map((tenant) => (
         <OptionsMenuItem
           onSelect={onSelect}
           isSelected={selectedTenant === tenant}

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -1,12 +1,13 @@
+import '@patternfly/patternfly/patternfly.css';
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Link, Route, useHistory, useParams } from 'react-router-dom';
-import LogsDetailPage from './pages/logs-detail-page';
-import LogsPage from './pages/logs-page';
-import '@patternfly/patternfly/patternfly.css';
-import LogsDevPage from './pages/logs-dev-page';
+import LogsAlertMetrics from './components/alerts/logs-alerts-metrics';
 import './index.css';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import LogsDetailPage from './pages/logs-detail-page';
+import LogsDevPage from './pages/logs-dev-page';
+import LogsPage from './pages/logs-page';
 
 const DevConsole = () => {
   const { ns: namespace } = useParams<{ ns: string }>();
@@ -105,6 +106,14 @@ const EndToEndTestsApp = () => {
           </Route>
           <Route path="/k8s/ns/:ns/pods/:name">
             <LogsDetailPage />
+          </Route>
+          <Route path="/monitoring/alerts/:alertname">
+            <LogsAlertMetrics
+              rule={{
+                labels: { tenantId: 'application' },
+                query: `sum by(job)(rate({ job=~".+" }[5m])) > 0`,
+              }}
+            />
           </Route>
         </main>
       </BrowserRouter>

--- a/web/src/getAlertingRules.ts
+++ b/web/src/getAlertingRules.ts
@@ -1,0 +1,39 @@
+import { RulesResponse } from './logs.types';
+import { getRules } from './loki-client';
+import { TENANTS } from './tenants';
+
+const abortControllers: Map<string, null | (() => void)> = new Map();
+
+const getAlertingRules = async () => {
+  const rulesResponses = await Promise.allSettled(
+    TENANTS.map((tenant) => {
+      if (abortControllers.has(tenant)) {
+        abortControllers.get(tenant)?.();
+      }
+
+      const { abort, request } = getRules({ tenant });
+      abortControllers.set(tenant, abort);
+
+      return request();
+    }),
+  );
+
+  const mergedRules: RulesResponse = rulesResponses
+    .flatMap((response) =>
+      response.status === 'fulfilled' && response.value.status === 'success'
+        ? [response.value]
+        : [],
+    )
+    .reduce(
+      (acc, rules) => {
+        acc.data.groups = acc.data.groups.concat(rules.data.groups);
+
+        return acc;
+      },
+      { data: { groups: [] }, status: 'success' } as RulesResponse,
+    );
+
+  return mergedRules;
+};
+
+export default getAlertingRules;

--- a/web/src/hooks/useRefWidth.ts
+++ b/web/src/hooks/useRefWidth.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+// SDK: use from SDK when it becomes available
+export const useRefWidth = () => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState<number>();
+
+  const setRef = useCallback((e: HTMLDivElement) => {
+    const newWidth = e?.clientWidth;
+    newWidth && ref.current?.clientWidth !== newWidth && setWidth(e.clientWidth);
+    ref.current = e;
+  }, []);
+
+  useEffect(() => {
+    const handleResize = () => setWidth(ref.current?.clientWidth);
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('sidebar_toggle', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('sidebar_toggle', handleResize);
+    };
+  }, []);
+
+  const clientWidth = ref.current?.clientWidth;
+
+  useEffect(() => {
+    width !== clientWidth && setWidth(clientWidth);
+  }, [clientWidth, width]);
+
+  return [setRef, width] as [React.Ref<HTMLDivElement>, number];
+};

--- a/web/src/logs.types.ts
+++ b/web/src/logs.types.ts
@@ -1,6 +1,7 @@
 export type Config = {
   useTenantInHeader?: boolean;
   isStreamingEnabledInDefaultPage?: boolean;
+  lokiTenanLabelKey?: string;
 };
 
 export type MetricValue = Array<number | string>;
@@ -53,5 +54,19 @@ export type QueryRangeResponse<T = MatrixResult | StreamsResult> = {
       store: Record<string, number>;
       summary: Record<string, number>;
     };
+  };
+};
+
+export type Rule = {
+  query?: string;
+  labels?: Record<string, string>;
+};
+
+export type RulesResponse = {
+  status: string;
+  data: {
+    groups: Array<{
+      rules: Array<Rule>;
+    }>;
   };
 };

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -1,7 +1,7 @@
 import { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/ws-factory';
-import { CancellableFetch, cancellableFetch, RequestInitWithTimeout } from './cancellable-fetch';
 import { queryWithNamespace } from './attribute-filters';
-import { Config, Direction, QueryRangeResponse } from './logs.types';
+import { CancellableFetch, cancellableFetch, RequestInitWithTimeout } from './cancellable-fetch';
+import { Config, Direction, QueryRangeResponse, RulesResponse } from './logs.types';
 import { durationFromTimestamp } from './value-utils';
 
 const LOKI_ENDPOINT = '/api/proxy/plugin/logging-view-plugin/backend';
@@ -33,6 +33,7 @@ export const getFetchConfig = ({
 }: {
   config?: Config;
   tenant: string;
+  endpoint?: string;
 }): { requestInit?: RequestInitWithTimeout; endpoint: string } => {
   if (config && config.useTenantInHeader === true) {
     return {
@@ -142,4 +143,13 @@ export const connectToTailSocket = ({
     subprotocols: ['json'],
     jsonParse: true,
   });
+};
+
+export const getRules = ({ config, tenant }: { config?: Config; tenant: string }) => {
+  const { endpoint, requestInit } = getFetchConfig({
+    config,
+    tenant,
+  });
+
+  return cancellableFetch<RulesResponse>(`${endpoint}/prometheus/api/v1/rules`, requestInit);
 };

--- a/web/src/tenants.ts
+++ b/web/src/tenants.ts
@@ -1,0 +1,1 @@
+export const TENANTS = ['application', 'infrastructure', 'audit'];

--- a/web/src/test-ids.ts
+++ b/web/src/test-ids.ts
@@ -4,6 +4,7 @@ export enum TestIds {
   SyncButton = 'SyncButton',
   LogsHistogram = 'LogsHistogram',
   LogsTable = 'LogsTable',
+  LogsMetrics = 'LogsMetrics',
   LogsQueryInput = 'LogsQueryInput',
   ExecuteQueryButton = 'ExecuteQueryButton',
   TenantDropdown = 'TenantDropdown',


### PR DESCRIPTION
https://issues.redhat.com/browse/OU-103
https://issues.redhat.com/browse/OU-104

This PR will add:

- Metrics component to display loki based metrics on the alert detail view
- Fetch function to get alerts from loki so console can merge with the current prometheus alerts
- Add `config/alerts.patch.json` to provide the `alerts` feature on allowed OCP versions


https://user-images.githubusercontent.com/5461414/214549412-78c87f65-a1a2-46bd-9946-3b2ef00a047f.mov

