### PR TITLE
Handle empty metrics data in logs

### DIFF
--- a/web/cypress/fixtures/query-range-fixtures.ts
+++ b/web/cypress/fixtures/query-range-fixtures.ts
@@ -171,6 +171,89 @@ export const queryRangeMatrixValidResponse = () => {
 export const queryRangeMatrixInvalidResponse = () => {
   return {};
 };
+
+export const queryRangeMatrixEmptyResponse = () => {
+  return {
+    status: 'success',
+    data: {
+      resultType: 'matrix',
+      result: [],
+      stats: {
+        summary: {
+          bytesProcessedPerSecond: 0,
+          linesProcessedPerSecond: 0,
+          totalBytesProcessed: 0,
+          totalLinesProcessed: 0,
+          execTime: 0.029010703,
+          queueTime: 0,
+          subqueries: 4,
+          totalEntriesReturned: 0,
+        },
+        querier: {
+          store: {
+            totalChunksRef: 0,
+            totalChunksDownloaded: 0,
+            chunksDownloadTime: 0,
+            chunk: {
+              headChunkBytes: 0,
+              headChunkLines: 0,
+              decompressedBytes: 0,
+              decompressedLines: 0,
+              compressedBytes: 0,
+              totalDuplicates: 0,
+            },
+          },
+        },
+        ingester: {
+          totalReached: 16,
+          totalChunksMatched: 0,
+          totalBatches: 0,
+          totalLinesSent: 0,
+          store: {
+            totalChunksRef: 0,
+            totalChunksDownloaded: 0,
+            chunksDownloadTime: 0,
+            chunk: {
+              headChunkBytes: 0,
+              headChunkLines: 0,
+              decompressedBytes: 0,
+              decompressedLines: 0,
+              compressedBytes: 0,
+              totalDuplicates: 0,
+            },
+          },
+        },
+        cache: {
+          chunk: {
+            entriesFound: 0,
+            entriesRequested: 0,
+            entriesStored: 0,
+            bytesReceived: 0,
+            bytesSent: 0,
+            requests: 0,
+          },
+          index: {
+            entriesFound: 0,
+            entriesRequested: 0,
+            entriesStored: 0,
+            bytesReceived: 0,
+            bytesSent: 0,
+            requests: 0,
+          },
+          result: {
+            entriesFound: 3,
+            entriesRequested: 3,
+            entriesStored: 1,
+            bytesReceived: 638,
+            bytesSent: 0,
+            requests: 4,
+          },
+        },
+      },
+    },
+  };
+};
+
 export const queryRangeStreamsInvalidResponse = () => {
   return {};
 };

--- a/web/cypress/integration/logs-alerts.cy.ts
+++ b/web/cypress/integration/logs-alerts.cy.ts
@@ -1,5 +1,6 @@
 import { TestIds } from '../../src/test-ids';
 import {
+  queryRangeMatrixEmptyResponse,
   queryRangeMatrixInvalidResponse,
   queryRangeMatrixValidResponse,
 } from '../fixtures/query-range-fixtures';
@@ -46,6 +47,18 @@ describe('Alerts logs metrics', () => {
       .should('exist')
       .within(() => {
         cy.contains('Unexpected end of JSON input');
+      });
+  });
+
+  it('handles errors gracefully when a response is empty', () => {
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixEmptyResponse());
+
+    cy.visit(LOGS_ALERTS_PAGE_URL);
+
+    cy.getByTestId(TestIds.LogsMetrics)
+      .should('exist')
+      .within(() => {
+        cy.contains('No datapoints found');
       });
   });
 

--- a/web/src/components/alerts/logs-alerts-metrics.tsx
+++ b/web/src/components/alerts/logs-alerts-metrics.tsx
@@ -1,11 +1,8 @@
-import { Alert } from '@patternfly/react-core';
 import React, { useEffect } from 'react';
 import { useLogs } from '../../hooks/useLogs';
 import { Rule, TimeRange } from '../../logs.types';
-import { CenteredContainer } from '../centered-container';
 import { LogsMetrics } from '../logs-metrics';
 import { TimeRangeDropdown } from '../time-range-dropdown';
-import './logs-alerts-metrics.css';
 
 interface LogsAlertMetricsProps {
   rule?: Rule;
@@ -25,29 +22,21 @@ const LogsAlertMetrics: React.FC<LogsAlertMetricsProps> = ({ rule }) => {
     }
   }, [rule?.query, timeRange]);
 
+  const tenantError = !tenant
+    ? new Error(`label '${LOKI_TENANT_LABEL_KEY} is required to display the alert metrics`)
+    : undefined;
+
   return (
     <div className="co-logs-alert-metrics__container">
       <div className="co-logs-metrics__header">
         <TimeRangeDropdown value={timeRange} onChange={setTimeRange} />
       </div>
-      {tenant ? (
-        <LogsMetrics
-          logsData={logsData}
-          error={logsError}
-          isLoading={isLoadingLogsData}
-          timeRange={timeRange}
-        />
-      ) : (
-        <CenteredContainer>
-          <Alert
-            className="co-logs-metrics__error"
-            variant="danger"
-            isInline
-            isPlain
-            title={`label '${LOKI_TENANT_LABEL_KEY} is required to display the alert metrics`}
-          />
-        </CenteredContainer>
-      )}
+      <LogsMetrics
+        logsData={logsData}
+        error={logsError || tenantError}
+        isLoading={isLoadingLogsData}
+        timeRange={timeRange}
+      />
     </div>
   );
 };

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -93,6 +93,8 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
   const legendData = data?.map((series) => ({ childName: series.name, name: series.name }));
   const intervalValue = intervalFromTimeRange(timeRangeValue);
 
+  const dataIsEmpty = data ? data?.length === 0 : false;
+
   return (
     <div ref={containerRef} style={{ height: GRAPH_HEIGHT }} data-test={TestIds.LogsMetrics}>
       {error ? (
@@ -106,6 +108,10 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
         </CenteredContainer>
       ) : isLoading ? (
         <CenteredContainer>Loading...</CenteredContainer>
+      ) : dataIsEmpty ? (
+        <CenteredContainer>
+          <Alert variant="warning" isInline isPlain title="No datapoints found" />
+        </CenteredContainer>
       ) : data ? (
         <Chart
           containerComponent={

--- a/web/src/date-utils.ts
+++ b/web/src/date-utils.ts
@@ -40,31 +40,45 @@ const getPart = (
   type: 'day' | 'hour' | 'minute' | 'month' | 'second' | 'year',
 ) => parts.find((p) => p.type === type)?.value || '';
 
+const isDateValid = (date: Date | number) => {
+  if (typeof date === 'number') {
+    return !isNaN(date);
+  } else if (date instanceof Date) {
+    return !isNaN(date.getTime());
+  }
+
+  return false;
+};
+
 export const dateToFormat = (date: Date | number, format: DateFormat): string => {
-  switch (format) {
-    case DateFormat.TimeShort:
-      return timeShortFormatter.format(date);
-      break;
-    case DateFormat.TimeMed:
-      return timeMedFormatter.format(date);
-      break;
-    case DateFormat.DateMed: {
-      const parts = dateMedFormatter.formatToParts(date);
-      return `${getPart(parts, 'year')}-${getPart(parts, 'month')}-${getPart(parts, 'day')}`;
-    }
-    case DateFormat.TimeFull: {
-      const fractionalSeconds =
-        typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
-      return `${timeMedFormatter.format(date)}.${fractionalSeconds}`;
-    }
-    case DateFormat.Full:
-      {
+  if (isDateValid(date)) {
+    switch (format) {
+      case DateFormat.TimeShort:
+        return timeShortFormatter.format(date);
+        break;
+      case DateFormat.TimeMed:
+        return timeMedFormatter.format(date);
+        break;
+      case DateFormat.DateMed: {
+        const parts = dateMedFormatter.formatToParts(date);
+        return `${getPart(parts, 'year')}-${getPart(parts, 'month')}-${getPart(parts, 'day')}`;
+      }
+      case DateFormat.TimeFull: {
         const fractionalSeconds =
           typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
-        return `${dateTimeFormatter.format(date)}.${fractionalSeconds}`;
+        return `${timeMedFormatter.format(date)}.${fractionalSeconds}`;
       }
-      break;
+      case DateFormat.Full:
+        {
+          const fractionalSeconds =
+            typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
+          return `${dateTimeFormatter.format(date)}.${fractionalSeconds}`;
+        }
+        break;
+    }
   }
+
+  return '';
 };
 
 export const getTimeFormatFromTimeRange = (timeRange: TimeRangeNumber): DateFormat =>


### PR DESCRIPTION
This PR adds better error handling when log metrics returns empty data, also adds date validation in the case the returned data has invalid values.