### PR TITLE
Fix request timeout

### DIFF
--- a/src/__tests__/loki-client-spec.ts
+++ b/src/__tests__/loki-client-spec.ts
@@ -4,6 +4,7 @@ describe('Loki Client', () => {
   it('should generate a valid config', () => {
     expect(getFetchConfig({ config: undefined, tenant: 'application' })).toEqual({
       endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application',
+      requestInit: { timeout: undefined },
     });
     expect(getFetchConfig({ config: { useTenantInHeader: true }, tenant: 'application' })).toEqual({
       endpoint: '/api/proxy/plugin/logging-view-plugin/backend',
@@ -13,6 +14,16 @@ describe('Loki Client', () => {
       getFetchConfig({ config: { useTenantInHeader: false }, tenant: 'infrastructure' }),
     ).toEqual({
       endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure',
+      requestInit: { timeout: undefined },
+    });
+    expect(
+      getFetchConfig({
+        config: { useTenantInHeader: false, timeout: 45 },
+        tenant: 'infrastructure',
+      }),
+    ).toEqual({
+      endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure',
+      requestInit: { timeout: 45000 },
     });
   });
 });

--- a/src/cancellable-fetch.ts
+++ b/src/cancellable-fetch.ts
@@ -30,7 +30,7 @@ export const cancellableFetch = <T>(
     return response.json();
   });
 
-  const timeout = init?.timeout ?? 30 * 1000;
+  const timeout = init?.timeout ?? 60 * 1000;
 
   if (timeout <= 0) {
     return { request: () => fetchPromise, abort };

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,5 +1,4 @@
 import { TimeRangeNumber } from './logs.types';
-import { padLeadingZero } from './value-utils';
 
 export enum DateFormat {
   TimeShort,
@@ -56,14 +55,7 @@ export const dateToFormat = (date: Date | number, format: DateFormat): string =>
     case DateFormat.TimeFull: {
       const fractionalSeconds =
         typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
-      const parts = timeMedFormatter.formatToParts(date);
-      const hours = parseInt(getPart(parts, 'hour'), 10);
-      const clampedHours = !isNaN(hours) ? padLeadingZero(hours >= 24 ? 0 : hours) : '';
-
-      return `${clampedHours}:${getPart(parts, 'minute')}:${getPart(
-        parts,
-        'second',
-      )}.${fractionalSeconds}`;
+      return `${timeMedFormatter.format(date)}.${fractionalSeconds}`;
     }
     case DateFormat.Full:
       {

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,4 +1,5 @@
 import { TimeRangeNumber } from './logs.types';
+import { padLeadingZero } from './value-utils';
 
 export enum DateFormat {
   TimeShort,
@@ -55,7 +56,14 @@ export const dateToFormat = (date: Date | number, format: DateFormat): string =>
     case DateFormat.TimeFull: {
       const fractionalSeconds =
         typeof date === 'number' ? Math.floor(date % 1000) : date.getMilliseconds();
-      return `${timeMedFormatter.format(date)}.${fractionalSeconds}`;
+      const parts = timeMedFormatter.formatToParts(date);
+      const hours = parseInt(getPart(parts, 'hour'), 10);
+      const clampedHours = !isNaN(hours) ? padLeadingZero(hours >= 24 ? 0 : hours) : '';
+
+      return `${clampedHours}:${getPart(parts, 'minute')}:${getPart(
+        parts,
+        'second',
+      )}.${fractionalSeconds}`;
     }
     case DateFormat.Full:
       {

--- a/src/logs.types.ts
+++ b/src/logs.types.ts
@@ -1,6 +1,7 @@
 export type Config = {
   useTenantInHeader?: boolean;
   isStreamingEnabledInDefaultPage?: boolean;
+  timeout?: number;
 };
 
 export type MetricValue = Array<number | string>;

--- a/src/loki-client.ts
+++ b/src/loki-client.ts
@@ -38,12 +38,18 @@ export const getFetchConfig = ({
     return {
       requestInit: {
         headers: { 'X-Scope-OrgID': tenant },
+        timeout: config?.timeout ? config.timeout * 1000 : undefined,
       },
       endpoint: LOKI_ENDPOINT,
     };
   }
 
-  return { endpoint: `${LOKI_ENDPOINT}/api/logs/v1/${tenant}` };
+  return {
+    requestInit: {
+      timeout: config?.timeout ? config.timeout * 1000 : undefined,
+    },
+    endpoint: `${LOKI_ENDPOINT}/api/logs/v1/${tenant}`,
+  };
 };
 
 export const executeQueryRange = ({


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/LOG-3498

This PR increases the default fetch timeout to `60s` and allows the timeout to be configured using a ConfigMap (timeout value in seconds):

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: logging-view-config
  namespace: logging-view
  labels:
    app: logging-view-plugin
    app.kubernetes.io/part-of: logging-view-plugin
data:
  config: |
    {
      "timeout": 80
    }
```