### PR TITLE
Group alerts based on user or platforms source

### DIFF
--- a/config/alerts.patch.json
+++ b/config/alerts.patch.json
@@ -5,20 +5,42 @@
     "value": {
       "type": "console.alerts/rules-source",
       "properties": {
-        "id": "logging-loki",
+        "id": "user",
         "contextId": "observe-alerting",
-        "getAlertingRules": { "$codeRef": "getAlertingRules" }
+        "getAlertingRules": { "$codeRef": "getUserAlertingRules" }
       }
     }
   },
-
   {
     "op": "add",
     "path": "/extensions/0",
     "value": {
       "type": "console.alerts/rules-chart",
       "properties": {
-        "sourceId": "logging-loki",
+        "sourceId": "user",
+        "chart": { "$codeRef": "LogsAlertMetrics" }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/extensions/0",
+    "value": {
+      "type": "console.alerts/rules-source",
+      "properties": {
+        "id": "platform",
+        "contextId": "observe-alerting",
+        "getAlertingRules": { "$codeRef": "getPlatformAlertingRules" }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/extensions/0",
+    "value": {
+      "type": "console.alerts/rules-chart",
+      "properties": {
+        "sourceId": "platform",
         "chart": { "$codeRef": "LogsAlertMetrics" }
       }
     }

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -51,15 +51,30 @@
   {
     "type": "console.alerts/rules-source",
     "properties": {
-      "id": "logging-loki",
+      "id": "user",
       "contextId": "observe-alerting",
-      "getAlertingRules": { "$codeRef": "getAlertingRules" }
+      "getAlertingRules": { "$codeRef": "getUserAlertingRules" }
     }
   },
   {
     "type": "console.alerts/rules-chart",
     "properties": {
-      "sourceId": "logging-loki",
+      "sourceId": "user",
+      "chart": { "$codeRef": "LogsAlertMetrics" }
+    }
+  },
+  {
+    "type": "console.alerts/rules-source",
+    "properties": {
+      "id": "platform",
+      "contextId": "observe-alerting",
+      "getAlertingRules": { "$codeRef": "getPlatformAlertingRules" }
+    }
+  },
+  {
+    "type": "console.alerts/rules-chart",
+    "properties": {
+      "sourceId": "platform",
       "chart": { "$codeRef": "LogsAlertMetrics" }
     }
   }

--- a/web/cypress/integration/logs-alerts.cy.ts
+++ b/web/cypress/integration/logs-alerts.cy.ts
@@ -74,6 +74,8 @@ describe('Alerts logs metrics', () => {
       cy.contains('Last 6 hours').click();
     });
 
+    cy.wait(200);
+
     cy.get('@queryRangeMatrix.all').should('have.length.at.least', 2);
   });
 });

--- a/web/package.json
+++ b/web/package.json
@@ -88,7 +88,8 @@
       "LogsDetailPage": "./pages/logs-detail-page",
       "LogActionsProvider": "./hooks/useLogActionsExtension",
       "LogsDevPage": "./pages/logs-dev-page",
-      "getAlertingRules": "./getAlertingRules",
+      "getUserAlertingRules": "./getUserAlertingRules",
+      "getPlatformAlertingRules": "./getPlatformAlertingRules",
       "LogsAlertMetrics": "./components/alerts/logs-alerts-metrics"
     },
     "dependencies": {

--- a/web/src/getAlertingRules.ts
+++ b/web/src/getAlertingRules.ts
@@ -1,12 +1,11 @@
 import { RulesResponse } from './logs.types';
 import { getRules } from './loki-client';
-import { TENANTS } from './tenants';
 
 const abortControllers: Map<string, null | (() => void)> = new Map();
 
-const getAlertingRules = async () => {
+export const getAlertingRules = async (tenants: Array<string>) => {
   const rulesResponses = await Promise.allSettled(
-    TENANTS.map((tenant) => {
+    tenants.map((tenant) => {
       if (abortControllers.has(tenant)) {
         abortControllers.get(tenant)?.();
       }
@@ -35,5 +34,3 @@ const getAlertingRules = async () => {
 
   return mergedRules;
 };
-
-export default getAlertingRules;

--- a/web/src/getPlatformAlertingRules.ts
+++ b/web/src/getPlatformAlertingRules.ts
@@ -1,0 +1,5 @@
+import { getAlertingRules } from './getAlertingRules';
+
+const getPlatformAlertingRules = () => getAlertingRules(['infrastructure', 'audit']);
+
+export default getPlatformAlertingRules;

--- a/web/src/getUserAlertingRules.ts
+++ b/web/src/getUserAlertingRules.ts
@@ -1,0 +1,5 @@
+import { getAlertingRules } from './getAlertingRules';
+
+const getUserAlertingRules = () => getAlertingRules(['application']);
+
+export default getUserAlertingRules;


### PR DESCRIPTION
This PR will group the `audit` and `infrastructure` tenants into the platform alerts source, and `application` into user alerts source.

https://user-images.githubusercontent.com/5461414/223421482-0e6c10cd-b796-4768-956c-d000bdb7169e.mov

Image for testing: `quay.io/gbernal/logging-view-plugin:alert-sources`

