### PR TITLE
add missing permission message and debug suggestion

### DIFF
--- a/web/src/__tests__/value-utils.spec.ts
+++ b/web/src/__tests__/value-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   notEmptyString,
   millisecondsFromDuration,
   valueWithScalePrefix,
+  capitalize,
 } from '../value-utils';
 
 describe('value utils', () => {
@@ -33,5 +34,12 @@ describe('value utils', () => {
     expect(notEmptyString('foo')).toBe(true);
     expect(notEmptyString('')).toBe(false);
     expect(notEmptyString(undefined)).toBe(false);
+  });
+
+  it('should capitalize a string', () => {
+    expect(capitalize('foo')).toBe('Foo');
+    expect(capitalize('')).toBe('');
+    expect(capitalize('123')).toBe('123');
+    expect(capitalize()).toBe('');
   });
 });

--- a/web/src/components/error-message.css
+++ b/web/src/components/error-message.css
@@ -3,3 +3,7 @@
   margin-top: var(--pf-global--spacer--md);
   background-color: transparent;
 }
+
+.co-logs-table__row-error .pf-c-code-block__pre {
+  text-align: left;
+}

--- a/web/src/value-utils.ts
+++ b/web/src/value-utils.ts
@@ -78,3 +78,10 @@ export const getInitialTenantFromNamespace = (namespace?: string): string => {
 
   return DEFAULT_TENANT;
 };
+
+export const capitalize = (str?: string): string => {
+  if (!str) {
+    return '';
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/LOG-3750

Improves the message when logs cannot be fetched due to permissions, adds a suggestion on how to solve the issue.

![Screenshot 2023-03-24 at 10 38 40](https://user-images.githubusercontent.com/5461414/227483159-bd86ae96-f515-4ca0-85de-338b6a1a19e8.png)

