### PR TITLE
Make load more logs consistent with the sorting direction

### DIFF
--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { notUndefined } from '../value-utils';
 import { DateFormat, dateToFormat } from '../date-utils';
-import { isStreamsResult, QueryRangeResponse, StreamLogData } from '../logs.types';
+import { Direction, isStreamsResult, QueryRangeResponse, StreamLogData } from '../logs.types';
 import { severityFromString } from '../severity';
 import { TestIds } from '../test-ids';
 import { CenteredContainer } from './centered-container';
@@ -30,7 +30,8 @@ interface LogsTableProps {
   hasMoreLogsData?: boolean;
   isLoadingMore?: boolean;
   onLoadMore?: (lastTimestamp: number) => void;
-  onSortByDate?: (direction?: 'forward' | 'backward') => void;
+  onSortByDate?: (direction?: Direction) => void;
+  direction?: Direction;
   showResources?: boolean;
   isStreaming?: boolean;
   error?: unknown;
@@ -240,6 +241,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({
   onSortByDate,
   hasMoreLogsData,
   showResources = false,
+  direction,
   isStreaming,
   children,
   error,
@@ -249,7 +251,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({
   const [expandedItems, setExpandedItems] = React.useState<Set<number>>(new Set());
   const [sortBy, setSortBy] = React.useState<ISortBy>({
     index: 0,
-    direction: 'desc',
+    direction: direction === 'backward' ? 'desc' : 'asc',
   });
   const tableData = React.useMemo(() => aggregateStreamLogData(logsData), [logsData]);
 
@@ -264,11 +266,15 @@ export const LogsTable: React.FC<LogsTableProps> = ({
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy,
-    onSort: (_event, index, direction) => {
+    onSort: (_event, index, tableSortDirection) => {
       setExpandedItems(new Set());
-      setSortBy({ index, direction, defaultDirection: 'desc' });
+      setSortBy({ index, direction: tableSortDirection, defaultDirection: 'desc' });
       onSortByDate?.(
-        direction === undefined ? undefined : direction === 'desc' ? 'backward' : 'forward',
+        tableSortDirection === undefined
+          ? undefined
+          : tableSortDirection === 'desc'
+          ? 'backward'
+          : 'forward',
       );
     },
     columnIndex,

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -23,7 +23,7 @@ const DEFAULT_SHOW_RESOURCES = '0';
 export const DEFAULT_QUERY = '{ log_type=~".+" } | json';
 
 const getDirectionValue = (value?: string | null): Direction =>
-  value !== null ? (value === 'forward' ? 'forward' : 'backward') : undefined;
+  value !== null ? (value === 'forward' ? 'forward' : 'backward') : 'backward';
 
 export const useURLState = ({ defaultQuery = DEFAULT_QUERY, attributes }: UseURLStateHook) => {
   const queryParams = useQueryParams();

--- a/web/src/logs.types.ts
+++ b/web/src/logs.types.ts
@@ -11,7 +11,7 @@ export type MetricValue = Array<number | string>;
 export type TimeRangeText = { start: string; end: string };
 export type TimeRangeNumber = { start: number; end: number };
 export type TimeRange = TimeRangeText | TimeRangeNumber;
-export type Direction = undefined | 'forward' | 'backward';
+export type Direction = 'forward' | 'backward';
 
 export const timeRangeIsText = (value: TimeRange): value is TimeRangeText =>
   typeof value.end === 'string' && typeof value.start === 'string';

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -171,6 +171,7 @@ const LogsDetailPage: React.FunctionComponent = () => {
           isLoading={isLoadingLogsData}
           isLoadingMore={isLoadingMoreLogsData}
           hasMoreLogsData={hasMoreLogsData}
+          direction={direction}
           error={logsError}
         >
           <LogsToolbar

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -170,6 +170,7 @@ const LogsDevPage: React.FunctionComponent = () => {
           isLoading={isLoadingLogsData}
           isLoadingMore={isLoadingMoreLogsData}
           hasMoreLogsData={hasMoreLogsData}
+          direction={direction}
           showResources={areResourcesShown}
           isStreaming={isStreaming}
           error={logsError}

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -172,6 +172,7 @@ const LogsPage: React.FC = () => {
           isLoadingMore={isLoadingMoreLogsData}
           hasMoreLogsData={hasMoreLogsData}
           showResources={areResourcesShown}
+          direction={direction}
           isStreaming={isStreaming}
           error={logsError}
         >


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OU-166

This PR adds the correct sorting `start` and `end` params when loading more logs.