### PR TITLE
Disable cache for plugin entry files

### DIFF
--- a/pkg/server/manifest_handler.go
+++ b/pkg/server/manifest_handler.go
@@ -29,6 +29,8 @@ func manifestHandler(cfg *Config) http.HandlerFunc {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Expires", "0")
 
 		w.Write(patchedManifest)
 	})

--- a/pkg/server/testdata/index.html
+++ b/pkg/server/testdata/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  
+</body>
+</html>

--- a/pkg/server/testdata/plugin-entry.js
+++ b/pkg/server/testdata/plugin-entry.js
@@ -1,0 +1,1 @@
+console.log("plugin-entry.js");


### PR DESCRIPTION
Disable caching for plugin entry files to avoid stalled content after upgrading the plugin version