### PR TITLE
Fix query input events and logQL query parsing

### DIFF
--- a/web/src/__tests__/logql-query.spec.ts
+++ b/web/src/__tests__/logql-query.spec.ts
@@ -202,6 +202,35 @@ describe('LogQL query', () => {
           ],
         },
       },
+      {
+        query: '{ log_type =~ ".+" } | unknown',
+        expected: {
+          selectorMatchers: [{ label: 'log_type', operator: '=~', value: '".+"' }],
+          pipeline: [
+            {
+              operator: '|',
+              value: 'unknown',
+              labelsInFilter: [
+                {
+                  label: 'unknown',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        query: '{ log_type =~ ".+" } | ',
+        expected: {
+          selectorMatchers: [{ label: 'log_type', operator: '=~', value: '".+"' }],
+          pipeline: [
+            {
+              operator: '|',
+              value: undefined,
+            },
+          ],
+        },
+      },
     ].forEach(({ query, expected }) => {
       const logql = new LogQLQuery(query);
       expect(logql.streamSelector).toEqual(expected.selectorMatchers);
@@ -389,6 +418,30 @@ describe('LogQL query', () => {
       {
         query: '{ foo="var" } | json |= "line search"',
         expected: '{ foo="var" } | json |= "line search"',
+      },
+      {
+        query: '{ foo= } | json |= "line search"',
+        expected: '{ foo= } | json |= "line search"',
+      },
+      {
+        query: '{ foo="bar" } | json "line search"',
+        expected: '{ foo="bar" } | json "line search"',
+      },
+      {
+        query: '{ foo } | json |= "line search"',
+        expected: '{ foo } | json |= "line search"',
+      },
+      {
+        query: '{ foo="var" } | unknown',
+        expected: '{ foo="var" } | unknown',
+      },
+      {
+        query: '{ foo="var" } | ',
+        expected: '{ foo="var" } | ',
+      },
+      {
+        query: '{ foo="var" } |= ',
+        expected: '{ foo="var" } |= ',
       },
       {
         query: '1 + 1',

--- a/web/src/components/logs-query-input.tsx
+++ b/web/src/components/logs-query-input.tsx
@@ -18,7 +18,11 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({ value = '', onCh
   const [internalValue, setInternalValue] = React.useState(value);
   const [isValid, setIsValid] = React.useState(true);
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && internalValue.trim().length > 0) {
+    if (
+      (e.ctrlKey || e.shiftKey || e.metaKey) &&
+      e.key === 'Enter' &&
+      internalValue.trim().length > 0
+    ) {
       onRun?.();
     }
   };

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -94,11 +94,23 @@ export const useURLState = ({ defaultQuery = DEFAULT_QUERY, attributes }: UseURL
     setDirection(getDirectionValue(directionValue));
     setAreResourcesShown(showResourcesValue === '1');
     setFilters(filtersFromQuery({ query: queryValue, attributes }));
-    setTimeRange(
-      timeRangeStartValue && timeRangeEndValue
-        ? { start: timeRangeStartValue, end: timeRangeEndValue }
-        : undefined,
-    );
+    setTimeRange((prevTimeRange) => {
+      if (!timeRangeStartValue || !timeRangeEndValue) {
+        return undefined;
+      }
+
+      if (
+        prevTimeRange?.start === timeRangeStartValue &&
+        prevTimeRange?.end === timeRangeEndValue
+      ) {
+        return prevTimeRange;
+      }
+
+      return {
+        start: timeRangeStartValue,
+        end: timeRangeEndValue,
+      };
+    });
   }, [queryParams]);
 
   return {

--- a/web/src/logql-query.ts
+++ b/web/src/logql-query.ts
@@ -241,13 +241,20 @@ export class LogQLQuery {
     const stream =
       this.streamSelector.length > 0
         ? `{ ${this.streamSelector
-            .map(({ label, operator, value }) => `${label}${operator}${value}`)
+            .map(
+              ({ label, operator, value }) =>
+                `${label}${operator !== undefined ? operator : ''}${
+                  value !== undefined ? value : ''
+                }`,
+            )
             .join(', ')} }`
         : '';
 
     const pipeline =
       this.streamSelector.length > 0
-        ? `${this.pipeline.map(({ operator, value }) => ` ${operator} ${value}`).join('')}`
+        ? `${this.pipeline
+            .map(({ operator, value }) => ` ${operator} ${value !== undefined ? value : ''}`)
+            .join('')}`
         : '';
 
     query += stream + pipeline;


### PR DESCRIPTION
This PR fixes:
- Execute query only when a ctrl+enter keyboard command is pressed instead of every character, a query can still be triggered by a change in control components that update the query
- When a value on the logQL expression pipeline or label matcher is not defined, leave the value empty instead of adding `undefined`, keeping the initial query unchanged