### PR TITLE
Fix detail page resource toggle

### DIFF
--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -171,6 +171,7 @@ const LogsDetailPage: React.FunctionComponent = () => {
           isLoading={isLoadingLogsData}
           isLoadingMore={isLoadingMoreLogsData}
           hasMoreLogsData={hasMoreLogsData}
+          showResources={areResourcesShown}
           direction={direction}
           error={logsError}
         >


### PR DESCRIPTION
This PR fixes the resource link toggle on the pod detail page so it toggles correctly the resources on the logs table