### PR TITLE
OU-167: Show Query button is in "Streaming logs" status. 

### DIFF
--- a/web/src/hooks/useLogs.ts
+++ b/web/src/hooks/useLogs.ts
@@ -413,8 +413,6 @@ export const useLogs = (
     currentTenant.current = tenant ?? currentTenant.current;
     currentTime.current = Date.now();
 
-    const start = millisecondsFromDuration('1h');
-
     if (ws.current) {
       ws.current.destroy();
     }
@@ -423,7 +421,6 @@ export const useLogs = (
 
     ws.current = connectToTailSocket({
       query,
-      start,
       tenant: currentTenant.current,
       namespace,
     });

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -26,6 +26,16 @@ type HistogramQuerParams = {
   tenant: string;
 };
 
+type LokiTailQueryParams = {
+  query: string;
+  delay_for?: string;
+  limit?: number;
+  start?: number;
+  config?: Config;
+  namespace?: string;
+  tenant: string;
+};
+
 export const getFetchConfig = ({
   config,
   tenant,
@@ -118,13 +128,7 @@ export const executeHistogramQuery = ({
   );
 };
 
-export const connectToTailSocket = ({
-  query,
-  start,
-  config,
-  tenant,
-  namespace,
-}: Omit<QueryRangeParams, 'end'>) => {
+export const connectToTailSocket = ({ query, config, tenant, namespace }: LokiTailQueryParams) => {
   const extendedQuery = queryWithNamespace({
     query,
     namespace,
@@ -132,7 +136,6 @@ export const connectToTailSocket = ({
 
   const params = {
     query: extendedQuery,
-    start: String(start * 1000000),
     limit: String(config?.logsLimit ?? 200),
   };
 


### PR DESCRIPTION
**Related Issue** 
https://issues.redhat.com/browse/OU-167

**Overview** 
Updated loki-client so that the websocket remains open for logs streaming. The issue was because of a malformed websocket URL. Also updated the script start-console.sh to remove the existing env file before creating a new one.

**Explanation** 
Logs streaming begins by displaying logs from the past hour. Previously, we set this to `start=3600000` milliseconds (i.e. 1 hour) but the Loki HTTP API docs state this parameter should be in **nanoseconds Unix epoch** (e.g. `start=1685563694`, meaning May 31, 2023, 8:8:14PM GMT). Because we were not formatting the websocket url correctly we could not stream the logs. 

This PR removes the ‘start’ parameter because the Loki HTTP API already defaults the 'start' parameter to the past hour, ”`start`: The start time for the query as a nanosecond Unix epoch. Defaults to one hour ago.” (source: https://grafana.com/docs/loki/latest/api/#stream-log-messages). 

<img width="777" alt="image" src="https://github.com/openshift/logging-view-plugin/assets/59589720/6e7c30a8-bb5c-45b2-a339-33ee9a306981">


**Before** 
Websocket can not stream any logs and closes immediately after opening. 
<img width="1440" alt="[OU-167](https://issues.redhat.com//browse/OU-167) BEFORE" src="https://github.com/openshift/logging-view-plugin/assets/59589720/4bc147af-709b-4fca-9a65-fbd233afa6fd">

**After**
Websocket can now stream logs. 
<img width="1436" alt="image" src="https://github.com/openshift/logging-view-plugin/assets/59589720/66582259-36e7-436b-b031-7b754f972c54">


