### PR TITLE
Add error fix suggestion for too long input size

### DIFF
--- a/web/locales/en/plugin__logging-view-plugin.json
+++ b/web/locales/en/plugin__logging-view-plugin.json
@@ -7,6 +7,7 @@
   "Reduce the time range to decrease the number of results": "Reduce the time range to decrease the number of results",
   "Increase Loki &quot;max_query_length&quot; entry in configuration file": "Increase Loki &quot;max_query_length&quot; entry in configuration file",
   "Make sure you have an instance of LokiStack runnning": "Make sure you have an instance of LokiStack runnning",
+  "Select a namespace filter to improve the query performance": "Select a namespace filter to improve the query performance",
   "Make sure you have the required role to get audit, application or infrastructure logs": "Make sure you have the required role to get audit, application or infrastructure logs",
   "Ask your administrator to create a role or cluster role that includes the following rule": "Ask your administrator to create a role or cluster role that includes the following rule",
   "You may consider the following query changes to avoid this error": "You may consider the following query changes to avoid this error",

--- a/web/src/components/error-message.tsx
+++ b/web/src/components/error-message.tsx
@@ -75,6 +75,9 @@ const messages: (t: TFunction) => Record<string, React.ReactElement> = (t) => ({
   'cannot connect to LokiStack': (
     <Suggestion>{t('Make sure you have an instance of LokiStack runnning')}</Suggestion>
   ),
+  'input size too long': (
+    <Suggestion>{t('Select a namespace filter to improve the query performance')}</Suggestion>
+  ),
   forbidden: (
     <Suggestion>
       <p>


### PR DESCRIPTION
This PR adds a message to help the user fix the input size too long error, particularly when a non-admin user has access to too many namespaces