### PR TITLE
Add docker compose testing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ web/.nyc_output/
 /plugin-backend
 env.list
 .vscode
+hack/docker-compose/docker-compose-logs

--- a/hack/docker-compose/docker-compose.test.yml
+++ b/hack/docker-compose/docker-compose.test.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+networks:
+  inner:
+
+services:
+  loki:
+    image: grafana/loki:2.8.0
+    ports:
+      - 3200:3100
+    restart: unless-stopped
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/local-config.yml
+      - ./docker-compose-logs:/var/log
+      - ./loki/rules:/loki/rules
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - inner
+
+  promtail:
+    image: grafana/promtail:2.5.0
+    volumes:
+      - ./docker-compose-logs:/var/log
+      - ./loki/promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    restart: unless-stopped
+    networks:
+      - inner
+
+  log-generator:
+    image: quay.io/rojacob/cluster-logging-load-client:0.0.1-db25b80
+    restart: unless-stopped
+    volumes:
+      - ./docker-compose-logs:/var/log
+    command: generate --output-format=json --destination=file --file=/var/log/generated.log --log-lines-rate=5000 --threads=3
+    networks:
+      - inner
+
+  loki-proxy:
+    image: nginx:alpine
+    ports:
+      - 3100:80
+    volumes:
+      - ./proxy.conf:/etc/nginx/templates/default.conf.template
+    restart: unless-stopped
+    networks:
+      - inner

--- a/hack/docker-compose/loki/loki-config.yml
+++ b/hack/docker-compose/loki/loki-config.yml
@@ -1,0 +1,49 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: boltdb
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 168h
+
+storage_config:
+  boltdb:
+    directory: /tmp/loki/index
+
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /etc/loki/rules
+  rule_path: /tmp/loki/scratch
+  alertmanager_url: http://localhost
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/hack/docker-compose/loki/promtail-config.yml
+++ b/hack/docker-compose/loki/promtail-config.yml
@@ -1,0 +1,43 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: system
+    pipeline_stages:
+      - regex:
+          expression: '.*"lvl":"(?P<level>[a-zA-Z]+)"'
+      - labels:
+          level:
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          log_type: infrastructure
+          kubernetes_pod_name: alertmanager-main-0
+          kubernetes_container_name: test-container
+          kubernetes_namespace_name: openshift-monitoring
+          __path__: /var/log/*log
+  - job_name: system2
+    pipeline_stages:
+      - regex:
+          expression: '.*"lvl":"(?P<level>[a-zA-Z]+)"'
+      - labels:
+          level:
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs-duplicate
+          kubernetes_namespace_name: log-test
+          log_type: application
+          __path__: /var/log/*log
+          kubernetes_pod_name: alertmanager-main-0
+          kubernetes_container_name: test-container

--- a/hack/docker-compose/loki/rules/application/test-loki-rule.yml
+++ b/hack/docker-compose/loki/rules/application/test-loki-rule.yml
@@ -1,0 +1,39 @@
+groups:
+  - name: should_fire
+    rules:
+      - alert: ApplicationHighErrorRate
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High error rate
+          description: This is a test alert from loki stack to be firing
+  - name: should_not_fire
+    rules:
+      - alert: ApplicationHighRequestCount
+        expr: |
+          sum(rate({job=~"test"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High request count
+  - name: should_be_pending
+    rules:
+      - alert: ApplicationHighRequestCountPending
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1w
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High request count
+          description: This is a test alert from loki stack that should be pending

--- a/hack/docker-compose/loki/rules/fake/test-loki-rule.yml
+++ b/hack/docker-compose/loki/rules/fake/test-loki-rule.yml
@@ -1,0 +1,39 @@
+groups:
+  - name: should_fire
+    rules:
+      - alert: HighErrorRate
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High error rate
+          description: This is a test alert from loki stack to be firing
+  - name: should_not_fire
+    rules:
+      - alert: HighRequestCount
+        expr: |
+          sum(rate({job=~"test"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High request count
+  - name: should_be_pending
+    rules:
+      - alert: HighRequestCountPending
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1w
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: application
+        annotations:
+          summary: High request count
+          description: This is a test alert from loki stack that should be pending

--- a/hack/docker-compose/loki/rules/infrastructure/test-loki-rule.yml
+++ b/hack/docker-compose/loki/rules/infrastructure/test-loki-rule.yml
@@ -1,0 +1,39 @@
+groups:
+  - name: should_fire
+    rules:
+      - alert: ApplicationHighErrorRate
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: infrastructure
+        annotations:
+          summary: High error rate
+          description: This is a test alert from loki stack to be firing
+  - name: should_not_fire
+    rules:
+      - alert: ApplicationHighRequestCount
+        expr: |
+          sum(rate({job=~"test"}[5m])) by (job) > 0.0
+        for: 1m
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: infrastructure
+        annotations:
+          summary: High request count
+  - name: should_be_pending
+    rules:
+      - alert: ApplicationHighRequestCountPending
+        expr: |
+          sum(rate({job=~".+"}[5m])) by (job) > 0.0
+        for: 1w
+        labels:
+          severity: page
+          source: lokistack
+          tenantId: infrastructure
+        annotations:
+          summary: High request count
+          description: This is a test alert from loki stack that should be pending

--- a/hack/docker-compose/proxy.conf
+++ b/hack/docker-compose/proxy.conf
@@ -1,0 +1,39 @@
+server {
+  listen 80 default_server;
+  server_name _;
+  server_name_in_redirect off;
+  access_log  /var/log/nginx/access.log;
+  error_log  /var/log/nginx/error.log debug;
+
+  location / {
+    proxy_set_header Host $host;
+    proxy_pass http://loki:3100/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  location /api/logs/v1/application/ {
+    proxy_set_header Host $host;
+    proxy_pass http://loki:3100/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+  
+  location /api/logs/v1/audit/ {
+    proxy_set_header Host $host;
+    proxy_pass http://loki:3100/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  location /api/logs/v1/infrastructure/ {
+    proxy_set_header Host $host;
+    proxy_pass http://loki:3100/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -14,7 +14,11 @@ to build and run the plugin. To run OpenShift console in a container, either
 
 ### Running locally
 
-Make sure you have loki running on `http://localhost:3100`
+Use the testing docker-compose to spin up loki, promtail and the proper tenant based routing that [LokiStack](https://docs.openshift.com/container-platform/4.13/logging/cluster-logging-loki.html) uses.
+
+```sh
+docker-compose -f hack/docker-compose/docker-compose.test.yml up
+```
 
 In one terminal window, run:
 


### PR DESCRIPTION
This PR adds some testing files to be able to run Loki with the paths that LokiStack uses to mimic the environment in a cluster