### PR TITLE
OCPBUGS-14902: Loki search does not allow special chars

### DIFF
--- a/web/cypress/integration/logs-page.cy.ts
+++ b/web/cypress/integration/logs-page.cy.ts
@@ -346,7 +346,7 @@ describe('Logs Page', () => {
         .invoke('val')
         .should(
           'equal',
-          '{ log_type="application" } |= "line filter" | json | level=~"error|err|eror|info|inf|information|notice"',
+          '{ log_type="application" } |= `line filter` | json | level=~"error|err|eror|info|inf|information|notice"',
         );
     });
 
@@ -370,7 +370,7 @@ describe('Logs Page', () => {
         .invoke('val')
         .should(
           'equal',
-          '{ log_type="application", kubernetes_namespace_name="gitops" } |= "line filter" | json | level=~"error|err|eror|info|inf|information|notice"',
+          '{ log_type="application", kubernetes_namespace_name="gitops" } |= `line filter` | json | level=~"error|err|eror|info|inf|information|notice"',
         );
     });
 

--- a/web/src/attribute-filters.tsx
+++ b/web/src/attribute-filters.tsx
@@ -219,6 +219,7 @@ export const queryFromFilters = ({
 };
 
 const removeQuotes = (value?: string) => (value ? value.replace(/"/g, '') : '');
+const removeBacktick = (value?: string) => (value ? value.replace(/`/g, '') : '');
 
 export const filtersFromQuery = ({
   query,
@@ -253,7 +254,7 @@ export const filtersFromQuery = ({
         .filter(notUndefined);
       filters.severity = new Set(severityValues);
     } else if (pipelineStage.operator === '|=' && !filters.content) {
-      filters.content = new Set([removeQuotes(pipelineStage.value)]);
+      filters.content = new Set([removeBacktick(pipelineStage.value)]);
     }
   }
 
@@ -345,7 +346,7 @@ export const getContentPipelineStage = (filters?: Filters): PipelineStage | unde
     return undefined;
   }
 
-  return { operator: '|=', value: `"${textValue}"` };
+  return { operator: '|=', value: `\`${textValue}\`` };
 };
 
 export const getSeverityFilterPipelineStage = (filters?: Filters): PipelineStage | undefined => {


### PR DESCRIPTION
**Related Issue**
https://issues.redhat.com/browse/OCPBUGS-14902

**Summary** 
Fix the content filter by converting text input into a raw string (`<text…>`) instead of plain string ("<text>"). This allows special characters to be escaped within Loki LogQLs.

**Resources**
[https://grafana.com/blog/2021/01/05/how-to-escape-special-characters-with-lokis-logql](https://grafana.com/blog/2021/01/05/how-to-escape-special-characters-with-lokis-logql)

**Before** 
The text input ""manger-role"" causes a parsing error. 
<img width="1437" alt="Before" src="https://github.com/openshift/logging-view-plugin/assets/59589720/d7b01f25-429e-4bbc-997d-e01699843f28">

**After**
The text input is now wrapped in backtick (``) instead of quotes (""). The text input `"manger-role"` no longer causes a parsing error. 
<img width="1440" alt="After" src="https://github.com/openshift/logging-view-plugin/assets/59589720/52425f33-33dd-4c8b-9102-38754be8a3e8">


