### PR TITLE
LOG-4429: filter alerting rules tenant based on namespace

### DIFF
--- a/web/src/value-utils.ts
+++ b/web/src/value-utils.ts
@@ -72,12 +72,15 @@ export const padLeadingZero = (value: number, length = 2): string =>
 const DEFAULT_TENANT = 'application';
 
 export const getInitialTenantFromNamespace = (namespace?: string): string => {
-  if (namespace && /^openshift-|^openshift$|^default$|^kube-/.test(namespace)) {
+  if (namespace && namespaceBelongsToInfrastructureTenant(namespace)) {
     return 'infrastructure';
   }
 
   return DEFAULT_TENANT;
 };
+
+export const namespaceBelongsToInfrastructureTenant = (namespace: string): boolean =>
+  /^openshift-|^openshift$|^default$|^kube-/.test(namespace);
 
 export const capitalize = (str?: string): string => {
   if (!str) {


### PR DESCRIPTION
Fixes: [LOG-4429](https://issues.redhat.com/browse/LOG-4429) by filtering the tenant based on the namespace