### PR TITLE
LOG-4465: Display correct message if logQL expression has line formatting

### DIFF
--- a/web/cypress/fixtures/query-range-fixtures.ts
+++ b/web/cypress/fixtures/query-range-fixtures.ts
@@ -8,29 +8,34 @@ const generateStreamValues = ({
   nValues,
   startTime,
   message = 'loki_1      | level=info ts=2022-07-01T08:21:47.5874835Z caller=table.go:443 msg="cleaning up unwanted dbs from table index_19172"',
+  value,
 }: {
   message?: string;
   nValues: number;
   startTime: number;
-}) => Array.from({ length: nValues }, (_, i) => [startTime * 1e6 + i, message]);
+  value?: string;
+}) => Array.from({ length: nValues }, (_, i) => [startTime * 1e6 + i, value || message]);
 
 const generateStream = ({
   level,
   nValues,
   startTime,
   message,
+  value,
 }: {
   level: string;
   startTime: number;
   nValues: number;
   message?: string;
+  value?: string;
 }) => ({
   stream: {
     filename: '/var/log/out.log',
     job: 'varlogs',
     level,
+    message,
   },
-  values: generateStreamValues({ nValues, startTime, message }),
+  values: generateStreamValues({ nValues, startTime, message, value }),
 });
 
 export const queryRangeStreamsValidResponse = ({ message }: { message?: string }) => {
@@ -260,4 +265,140 @@ export const queryRangeStreamsInvalidResponse = () => {
 
 export const queryRangeStreamsErrorResponse = () => {
   return 'max entries limit';
+};
+
+export const queryRangeStreamsWithLineFormatting = () => {
+  const startTime = Date.now();
+
+  const message = `formatted string`;
+  const value = `formatted string`;
+
+  return {
+    status: 'success',
+    data: {
+      resultType: 'streams',
+      result: [
+        generateStream({
+          level: 'info',
+          nValues: 50,
+          startTime,
+          message,
+          value,
+        }),
+      ],
+      stats: {
+        summary: {
+          bytesProcessedPerSecond: 269479887,
+          linesProcessedPerSecond: 859141,
+          totalBytesProcessed: 28840573,
+          totalLinesProcessed: 91948,
+          execTime: 0.1070231,
+          queueTime: 0.0000893,
+          subqueries: 1,
+        },
+        querier: {
+          store: {
+            totalChunksRef: 0,
+            totalChunksDownloaded: 0,
+            chunksDownloadTime: 0,
+            chunk: {
+              headChunkBytes: 0,
+              headChunkLines: 0,
+              decompressedBytes: 0,
+              decompressedLines: 0,
+              compressedBytes: 0,
+              totalDuplicates: 0,
+            },
+          },
+        },
+        ingester: {
+          totalReached: 1,
+          totalChunksMatched: 8,
+          totalBatches: 2,
+          totalLinesSent: 200,
+          store: {
+            totalChunksRef: 8,
+            totalChunksDownloaded: 8,
+            chunksDownloadTime: 1248200,
+            chunk: {
+              headChunkBytes: 990544,
+              headChunkLines: 5782,
+              decompressedBytes: 27850029,
+              decompressedLines: 86166,
+              compressedBytes: 2935987,
+              totalDuplicates: 0,
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+export const queryRangeStreamsWithMessage = () => {
+  const startTime = Date.now();
+
+  const message = `a message`;
+  const value = `{ json:"object" }`;
+
+  return {
+    status: 'success',
+    data: {
+      resultType: 'streams',
+      result: [
+        generateStream({
+          level: 'info',
+          nValues: 50,
+          startTime,
+          message,
+          value,
+        }),
+      ],
+      stats: {
+        summary: {
+          bytesProcessedPerSecond: 269479887,
+          linesProcessedPerSecond: 859141,
+          totalBytesProcessed: 28840573,
+          totalLinesProcessed: 91948,
+          execTime: 0.1070231,
+          queueTime: 0.0000893,
+          subqueries: 1,
+        },
+        querier: {
+          store: {
+            totalChunksRef: 0,
+            totalChunksDownloaded: 0,
+            chunksDownloadTime: 0,
+            chunk: {
+              headChunkBytes: 0,
+              headChunkLines: 0,
+              decompressedBytes: 0,
+              decompressedLines: 0,
+              compressedBytes: 0,
+              totalDuplicates: 0,
+            },
+          },
+        },
+        ingester: {
+          totalReached: 1,
+          totalChunksMatched: 8,
+          totalBatches: 2,
+          totalLinesSent: 200,
+          store: {
+            totalChunksRef: 8,
+            totalChunksDownloaded: 8,
+            chunksDownloadTime: 1248200,
+            chunk: {
+              headChunkBytes: 990544,
+              headChunkLines: 5782,
+              decompressedBytes: 27850029,
+              decompressedLines: 86166,
+              compressedBytes: 2935987,
+              totalDuplicates: 0,
+            },
+          },
+        },
+      },
+    },
+  };
 };

--- a/web/cypress/integration/logs-page.cy.ts
+++ b/web/cypress/integration/logs-page.cy.ts
@@ -5,6 +5,8 @@ import {
   queryRangeStreamsErrorResponse,
   queryRangeStreamsInvalidResponse,
   queryRangeStreamsValidResponse,
+  queryRangeStreamsWithLineFormatting,
+  queryRangeStreamsWithMessage,
 } from '../fixtures/query-range-fixtures';
 import { namespaceListResponse } from '../fixtures/resource-api-fixtures';
 import { formatTimeRange } from '../../src/time-range';
@@ -475,6 +477,42 @@ describe('Logs Page', () => {
       .should('exist')
       .within(() => {
         cy.contains('Select a smaller time range to reduce the number of results');
+      });
+
+    cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
+  });
+
+  it('displays the content of a log entry if the stream result is already formatted', () => {
+    cy.intercept(QUERY_RANGE_STREAMS_URL_MATCH, queryRangeStreamsWithLineFormatting()).as(
+      'queryRangeStreams',
+    );
+
+    cy.visit(LOGS_PAGE_URL);
+
+    cy.getByTestId(TestIds.ExecuteQueryButton).click();
+
+    cy.getByTestId(TestIds.LogsTable)
+      .should('exist')
+      .within(() => {
+        cy.get('.co-logs-table__message').first().contains('formatted string');
+      });
+
+    cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
+  });
+
+  it('displays the message of a log entry if the streams result is an object', () => {
+    cy.intercept(QUERY_RANGE_STREAMS_URL_MATCH, queryRangeStreamsWithMessage()).as(
+      'queryRangeStreams',
+    );
+
+    cy.visit(LOGS_PAGE_URL);
+
+    cy.getByTestId(TestIds.ExecuteQueryButton).click();
+
+    cy.getByTestId(TestIds.LogsTable)
+      .should('exist')
+      .within(() => {
+        cy.get('.co-logs-table__message').first().contains('a message');
       });
 
     cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -69,6 +69,12 @@ type LogRowProps = {
   showResources: boolean;
 };
 
+const isJSONObject = (value: string): boolean => {
+  const trimmedValue = value.trim();
+
+  return trimmedValue.startsWith('{') && trimmedValue.endsWith('}');
+};
+
 const parseResources = (data: Record<string, string>): Array<Resource> => {
   const container = data['kubernetes_container_name']
     ? {
@@ -96,7 +102,8 @@ const streamToTableData = (stream: StreamLogData): Array<LogTableData> => {
   const values = stream.values;
 
   return values.map((value) => {
-    const message = String(stream.stream['message'] || value[1]);
+    const logValue = String(value[1]);
+    const message = isJSONObject(logValue) ? stream.stream['message'] || logValue : logValue;
     const timestamp = parseFloat(String(value[0]));
     const time = timestamp / 1e6;
     const formattedTime = dateToFormat(time, DateFormat.Full);


### PR DESCRIPTION
Display the content of the log if the log is not a json object, which means is already formatted.

fixes: https://issues.redhat.com/browse/OCPBUGS-11977