### PR TITLE
OU-223: add all namespaces check to dev console view

### DIFF
--- a/web/cypress/integration/logs-dev-page.cy.ts
+++ b/web/cypress/integration/logs-dev-page.cy.ts
@@ -34,6 +34,7 @@ describe('Logs Dev Page', () => {
 
     cy.getByTestId(TestIds.ShowQueryToggle).click();
     cy.getByTestId(TestIds.LogsQueryInput).should('exist');
+    cy.getByTestId(TestIds.SearchAllNamespacesToggle).should('exist');
 
     cy.getByTestId(TestIds.LogsTable)
       .should('exist')

--- a/web/locales/en/plugin__logging-view-plugin.json
+++ b/web/locales/en/plugin__logging-view-plugin.json
@@ -67,5 +67,6 @@
   "Start streaming": "Start streaming",
   "See related logs": "See related logs",
   "Aggregated Logs": "Aggregated Logs",
-  "Logs": "Logs"
+  "Logs": "Logs",
+  "Search in all namespaces": "Search in all namespaces"
 }

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  Checkbox,
   Select,
   SelectOption,
   SelectOptionObject,
@@ -37,8 +38,11 @@ interface LogsToolbarProps {
   onStreamingToggle?: (e: React.MouseEvent) => void;
   onSeverityChange?: (severityFilter: Set<Severity>) => void;
   onShowResourcesToggle?: (showResources: boolean) => void;
+  onSearchInAllNamespacesToggle?: (searchInAllNamespaces: boolean) => void;
   showResources?: boolean;
   enableTenantDropdown?: boolean;
+  enableSearchInAllNamespaces?: boolean;
+  searchInAllNamespaces?: boolean;
   isDisabled?: boolean;
   onFiltersChange?: (filters: Filters) => void;
   filters?: Filters;
@@ -63,10 +67,13 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   onTenantSelect,
   onStreamingToggle,
   onShowResourcesToggle,
+  onSearchInAllNamespacesToggle,
   showResources = false,
   enableStreaming = false,
   isStreaming = false,
   enableTenantDropdown = true,
+  enableSearchInAllNamespaces = false,
+  searchInAllNamespaces = false,
   isDisabled = false,
   filters,
   onFiltersChange,
@@ -163,6 +170,18 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
               onTenantSelected={onTenantSelect}
               selectedTenant={tenant}
               isDisabled={isDisabled}
+            />
+          </ToolbarGroup>
+        )}
+
+        {enableSearchInAllNamespaces && (
+          <ToolbarGroup>
+            <Checkbox
+              isChecked={searchInAllNamespaces}
+              onChange={(checked) => onSearchInAllNamespacesToggle?.(checked)}
+              id="search-all-namespaces-checkbox"
+              label={t('Search all namespaces')}
+              data-test={TestIds.SearchAllNamespacesToggle}
             />
           </ToolbarGroup>
         )}

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -18,9 +18,11 @@ const TIME_RANGE_END = 'end';
 const DIRECTION = 'direction';
 const TENANT_PARAM_KEY = 'tenant';
 const SHOW_RESOURCES_PARAM_KEY = 'showResources';
+const SEARCH_ALL_NAMESPACES_PARAM_KEY = 'searchAllNamespaces';
 
 const DEFAULT_TENANT = 'application';
 const DEFAULT_SHOW_RESOURCES = '0';
+const DEFAULT_SEARCH_ALL_NAMESPACES = '0';
 export const defaultQueryFromTenant = (tenant: string = DEFAULT_TENANT) =>
   `{ log_type="${tenant}" } | json`;
 
@@ -44,6 +46,8 @@ export const useURLState = ({
   const initialDirection = queryParams.get(DIRECTION);
   const initialResorcesShown =
     (queryParams.get(SHOW_RESOURCES_PARAM_KEY) ?? DEFAULT_SHOW_RESOURCES) === '1';
+  const initialSearchInAllNamespaces =
+    (queryParams.get(SEARCH_ALL_NAMESPACES_PARAM_KEY) ?? DEFAULT_SEARCH_ALL_NAMESPACES) === '1';
 
   const [query, setQuery] = React.useState(initialQuery);
   const [tenant, setTenant] = React.useState(initialTenant);
@@ -51,6 +55,9 @@ export const useURLState = ({
     filtersFromQuery({ query: initialQuery, attributes }),
   );
   const [areResourcesShown, setAreResourcesShown] = React.useState<boolean>(initialResorcesShown);
+  const [searchAllNamespaces, setSearchAllNamespaces] = React.useState<boolean>(
+    initialSearchInAllNamespaces,
+  );
   const [direction, setDirection] = React.useState<Direction>(getDirectionValue(initialDirection));
   const [timeRange, setTimeRange] = React.useState<TimeRange | undefined>(
     initialTimeRangeStart && initialTimeRangeEnd
@@ -68,6 +75,11 @@ export const useURLState = ({
 
   const setShowResourcesInURL = (showResources: boolean) => {
     queryParams.set(SHOW_RESOURCES_PARAM_KEY, showResources ? '1' : '0');
+    history.push(`${location.pathname}?${queryParams.toString()}`);
+  };
+
+  const setSearchAllNamespacesInURL = (enableSearchAllNamespacesValue: boolean) => {
+    queryParams.set(SEARCH_ALL_NAMESPACES_PARAM_KEY, enableSearchAllNamespacesValue ? '1' : '0');
     history.push(`${location.pathname}?${queryParams.toString()}`);
   };
 
@@ -96,6 +108,8 @@ export const useURLState = ({
     const queryValue = queryParams.get(QUERY_PARAM_KEY) ?? initialQuery;
     const tenantValue = queryParams.get(TENANT_PARAM_KEY) ?? DEFAULT_TENANT;
     const showResourcesValue = queryParams.get(SHOW_RESOURCES_PARAM_KEY) ?? DEFAULT_SHOW_RESOURCES;
+    const searchAllNamespacesValue =
+      queryParams.get(SEARCH_ALL_NAMESPACES_PARAM_KEY) ?? DEFAULT_SEARCH_ALL_NAMESPACES;
     const timeRangeStartValue = queryParams.get(TIME_RANGE_START);
     const timeRangeEndValue = queryParams.get(TIME_RANGE_END);
     const directionValue = queryParams.get(DIRECTION);
@@ -104,6 +118,7 @@ export const useURLState = ({
     setTenant(tenantValue);
     setDirection(getDirectionValue(directionValue));
     setAreResourcesShown(showResourcesValue === '1');
+    setSearchAllNamespaces(searchAllNamespacesValue === '1');
     setFilters(filtersFromQuery({ query: queryValue, attributes }));
     setTimeRange((prevTimeRange) => {
       if (!timeRangeStartValue || !timeRangeEndValue) {
@@ -130,7 +145,9 @@ export const useURLState = ({
     tenant,
     setTenantInURL,
     areResourcesShown,
+    searchAllNamespaces,
     setShowResourcesInURL,
+    setSearchAllNamespacesInURL,
     filters,
     setFilters,
     timeRange,

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -38,6 +38,8 @@ const LogsDevPage: React.FunctionComponent = () => {
     setQueryInURL,
     areResourcesShown,
     setShowResourcesInURL,
+    searchAllNamespaces,
+    setSearchAllNamespacesInURL,
     filters,
     setFilters,
     setTimeRangeInURL,
@@ -81,14 +83,19 @@ const LogsDevPage: React.FunctionComponent = () => {
   const runQuery = ({ queryToUse }: { queryToUse?: string } = {}) => {
     getLogs({
       query: queryToUse ?? query,
-      namespace,
+      namespace: searchAllNamespaces ? undefined : namespace,
       timeRange,
       direction,
       tenant,
     });
 
     if (isHistogramVisible) {
-      getHistogram({ query: queryToUse ?? query, namespace, timeRange, tenant });
+      getHistogram({
+        query: queryToUse ?? query,
+        namespace: searchAllNamespaces ? undefined : namespace,
+        timeRange,
+        tenant,
+      });
     }
   };
 
@@ -141,7 +148,7 @@ const LogsDevPage: React.FunctionComponent = () => {
     const queryToUse = updateQuery(filters, tenant);
 
     runQuery({ queryToUse });
-  }, [timeRange, isHistogramVisible, namespace, direction]);
+  }, [timeRange, isHistogramVisible, namespace, searchAllNamespaces, direction]);
 
   const isQueryEmpty = query === '';
 
@@ -212,6 +219,9 @@ const LogsDevPage: React.FunctionComponent = () => {
             attributeList={attributeList}
             filters={filters}
             onFiltersChange={handleFiltersChange}
+            searchInAllNamespaces={searchAllNamespaces}
+            onSearchInAllNamespacesToggle={setSearchAllNamespacesInURL}
+            enableSearchInAllNamespaces
           />
         </LogsTable>
       </Grid>

--- a/web/src/test-ids.ts
+++ b/web/src/test-ids.ts
@@ -15,4 +15,5 @@ export enum TestIds {
   TimeRangeSelectModal = 'TimeRangeSelectModal',
   TimeRangeDropdownSaveButton = 'TimeRangeDropdownSaveButton',
   ToggleHistogramButton = 'ToggleHistogramButton',
+  SearchAllNamespacesToggle = 'SearchAllNamespacesToggle',
 }


### PR DESCRIPTION
This PR adds a checkbox in the dev perspective logs view that removes the current namespace filter so dev users can search in all namespaces they have access to. 

https://github.com/openshift/logging-view-plugin/assets/5461414/96b115ec-6e2b-4379-ab0b-2831edf076a2

