### PR TITLE
OU-199: Use korrel8r to load logs related to an alert

### DIFF
--- a/logging-view-plugin-resources.yml
+++ b/logging-view-plugin-resources.yml
@@ -106,13 +106,22 @@ spec:
     basePath: "/"
     port: 9443
   proxy:
-    - type: Service
-      alias: backend
-      authorize: true
-      service:
-        name: lokistack-sample-gateway-http
-        namespace: openshift-logging
-        port: 8080
+    - alias: backend
+      authorization: UserToken
+      endpoint:
+        service:
+          name: logging-loki-gateway-http
+          namespace: openshift-logging
+          port: 8080
+        type: Service
+    - alias: korrel8r
+      authorization: None
+      endpoint:
+        service:
+          name: korrel8r
+          namespace: korrel8r
+          port: 443
+        type: Service
 
 ---
 apiVersion: v1

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -1,0 +1,32 @@
+import { cancellableFetch, RequestInitWithTimeout } from './cancellable-fetch';
+import { GoalsRequest, Korrel8rResponse } from './korrel8r.types';
+import { Config } from './logs.types';
+
+const KORREL8R_ENDPOINT = '/api/proxy/plugin/logging-view-plugin/korrel8r';
+
+export const getFetchConfig = ({
+  config,
+}: {
+  config?: Config;
+}): { requestInit?: RequestInitWithTimeout; endpoint: string } => {
+  return {
+    requestInit: {
+      timeout: config?.timeout ? config.timeout * 1000 : undefined,
+    },
+    endpoint: KORREL8R_ENDPOINT,
+  };
+};
+
+export const listGoals = ({
+  config,
+  goalsRequest,
+}: {
+  config?: Config;
+  goalsRequest: GoalsRequest;
+}) => {
+  const { endpoint, requestInit } = getFetchConfig({ config });
+
+  const requestData = { ...requestInit, method: 'POST', body: JSON.stringify(goalsRequest) };
+
+  return cancellableFetch<Korrel8rResponse>(`${endpoint}/api/v1alpha1/lists/goals`, requestData);
+};

--- a/web/src/korrel8r.types.ts
+++ b/web/src/korrel8r.types.ts
@@ -1,0 +1,27 @@
+export type Node = {
+  class: string;
+  count: number;
+  queries?: Array<{
+    count: number;
+    query: {
+      LogQL: string;
+      LogType: string;
+    };
+  }>;
+};
+
+export type Start = {
+  class: string;
+  queries: Array<{
+    Labels: {
+      alertname: string;
+    };
+  }>;
+};
+
+export type GoalsRequest = {
+  goals: Array<string>;
+  start: Start;
+};
+
+export type Korrel8rResponse = Array<Node>;


### PR DESCRIPTION
With this PR, we just use the first korrel8r goal that has some LogQL results. In other words, if the korrel8r API returns multiple LogQL queries that have results, we ignore all but the first one in the API response.


https://github.com/openshift/logging-view-plugin/assets/460802/30a61144-82bc-42b2-adfb-2608065b1e31

