### PR TITLE
LOG-4666: Fix http2 rapid reset upgrading golang.org/x/net

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 ./web/node_modules
 ./web/dist
 ./plugin-backend
+./test-certs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ web/.nyc_output/
 /plugin-backend
 env.list
 .vscode
+hack/docker-compose/docker-compose-logs
+test-certs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/nodejs-16:1-72 AS web-builder
+FROM registry.redhat.io/ubi9/nodejs-18:latest AS web-builder
 
 WORKDIR /opt/app-root
 
@@ -11,7 +11,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM registry.redhat.io/ubi8/go-toolset:1.18 as go-builder
+FROM registry.redhat.io/ubi9/go-toolset:1.19 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -27,7 +27,7 @@ COPY pkg/ pkg/
 
 RUN make build-backend
 
-FROM registry.access.redhat.com/ubi8-micro:8.7-1
+FROM registry.redhat.io/ubi9/ubi-minimal
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,10 +1,10 @@
-FROM registry.redhat.io/ubi8/ubi-minimal:8.6 as web-builder
+FROM registry.redhat.io/ubi9/ubi-minimal as web-builder
 
 ENV APP_ROOT=/opt/app-root \
     HOME=/opt/app-root/src \
     NPM_RUN=start \
     PLATFORM="el8" \
-    NODEJS_VERSION=16 \
+    NODEJS_VERSION=18 \
     NPM_RUN=start \
     NAME=nodejs
 
@@ -12,9 +12,9 @@ ENV NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 RUN INSTALL_PKGS="nodejs nodejs-nodemon npm findutils tar make" && \
-    microdnf module disable nodejs && \
-    microdnf module enable nodejs:$NODEJS_VERSION && \
-    microdnf --nodocs install $INSTALL_PKGS && \
+    microdnf module disable nodejs -y && \
+    microdnf module enable nodejs:$NODEJS_VERSION -y && \
+    microdnf --nodocs install $INSTALL_PKGS -y && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
@@ -28,7 +28,7 @@ RUN make install-frontend-ci
 COPY web/ ${HOME}/web
 RUN make build-frontend
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as go-builder
+FROM registry.redhat.io/ubi9/go-toolset:1.19 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -44,7 +44,7 @@ COPY pkg/ pkg/
 
 RUN make build-backend
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.6
+FROM registry.redhat.io/ubi9/ubi-minimal
 
 USER 1001
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/logging-view-plugin
 
-go 1.18
+go 1.20
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
@@ -18,6 +18,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,9 +30,11 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
update images to ubi9, golang version and golang.org/x/net

Manual cherry pick of #144