### PR TITLE
Add go flags to correct dependency expectations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 FEATURES?=
 
+BUILD_OPTS?=-mod=mod
+export GOROOT=$(shell go env GOROOT)
+export GOFLAGS=
+export GODEBUG=x509ignoreCN=0
+
 .PHONY: install-frontend
 install-frontend:
 	cd web && npm install
@@ -38,7 +43,7 @@ install-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build -o plugin-backend cmd/plugin-backend.go
+	go build $(BUILD_OPTS) -o plugin-backend cmd/plugin-backend.go
 
 .PHONY: test-unit-backend
 test-unit-backend:


### PR DESCRIPTION
Fix to resolve which blocks https://github.com/openshift/release/pull/44977
```
[2/3] STEP 10/11: COPY pkg/ pkg/
[2/3] STEP 11/11: RUN make build-backend
go build -o plugin-backend cmd/plugin-backend.go
go: inconsistent vendoring in /opt/app-root:
	github.com/evanphx/json-patch@v5.6.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/gorilla/handlers@v1.5.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/gorilla/mux@v1.8.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/sirupsen/logrus@v1.9.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/stretchr/testify@v1.8.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	gopkg.in/yaml.v3@v3.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/davecgh/go-spew@v1.1.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/felixge/httpsnoop@v1.0.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/kr/text@v0.2.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/pkg/errors@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/pmezard/go-difflib@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/sys@v0.13.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
```