### PR TITLE
Added -mod=readonly to make the CI go builder happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build -o plugin-backend cmd/plugin-backend.go
+	go build -mod=readonly -o plugin-backend cmd/plugin-backend.go
 
 .PHONY: test-unit-backend
 test-unit-backend:


### PR DESCRIPTION
This is to fix a build error when building with the CI go builder image:
```
$ make build-backend
go build -o plugin-backend cmd/plugin-backend.go
go: inconsistent vendoring in /home/syedriko/go/src/github.com/openshift/logging-view-plugin:
	github.com/evanphx/json-patch@v5.6.0+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	...
```

Here is an example: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/46011/rehearse-46011-pull-ci-openshift-logging-view-plugin-release-5.6-images/1729191600048836608/build-log.txt