### PR TITLE
[release-5.6] Update owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,12 @@
 reviewers:
   - jgbernalp
   - kyoto
+  - zhuje
 approvers:
   - jgbernalp
   - kyoto
+  - jcantrill
+  - alanconway
+  - periklis
+  - xperimental
+  - zhuje


### PR DESCRIPTION
Bring the owners file to the same state as in `main`. The aim of this PR is mostly to trigger another run of the CI.