### PR TITLE
LOG-4905: merge react router url params with props

### DIFF
--- a/config/dev-console.patch.json
+++ b/config/dev-console.patch.json
@@ -7,7 +7,7 @@
       "properties": {
         "contextId": "dev-console-observe",
         "name": "%plugin__logging-view-plugin~Logs%",
-        "href": "/logs",
+        "href": "logs",
         "component": {
           "$codeRef": "LogsDevPage"
         }

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -37,7 +37,7 @@
     "properties": {
       "contextId": "dev-console-observe",
       "name": "%plugin__logging-view-plugin~Logs%",
-      "href": "/logs",
+      "href": "logs",
       "component": { "$codeRef": "LogsDevPage" }
     }
   },

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -35,15 +35,26 @@ t('plugin__logging-view-plugin~Aggregated Logs')
 
 */
 
-const LogsDetailPage: React.FunctionComponent = () => {
+interface LogsDetailPageProps {
+  ns?: string;
+  name?: string;
+}
+
+const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
+  ns: namespaceFromProps,
+  name: podNameFromProps,
+}) => {
   const { t } = useTranslation('plugin__logging-view-plugin');
 
-  const { name: podname, ns: namespace } = useParams<{ name: string; ns: string }>();
+  const { name: podnameFromParams, ns: namespaceFromParams } =
+    useParams<{ name: string; ns: string }>();
+  const namespace = namespaceFromParams || namespaceFromProps;
+  const podname = podnameFromParams || podNameFromProps;
   const defaultQuery = `{ kubernetes_pod_name = "${podname}" } | json`;
   const [isHistogramVisible, setIsHistogramVisible] = React.useState(false);
 
   const attributesForPod: AttributeList = React.useMemo(
-    () => availablePodAttributes(namespace, podname),
+    () => (namespace && podname ? availablePodAttributes(namespace, podname) : []),
     [podname],
   );
 

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -31,8 +31,13 @@ t('plugin__logging-view-plugin~Logs')
 
 */
 
-const LogsDevPage: React.FunctionComponent = () => {
-  const { ns: namespace } = useParams<{ ns: string }>();
+interface LogsDevPageProps {
+  ns?: string;
+}
+
+const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => {
+  const { ns: namespaceFromParams } = useParams<{ ns: string }>();
+  const namespace = namespaceFromParams || namespaceFromProps;
   const [isHistogramVisible, setIsHistogramVisible] = React.useState(false);
   let tenant = getInitialTenantFromNamespace(namespace);
 
@@ -136,7 +141,10 @@ const LogsDevPage: React.FunctionComponent = () => {
     }
   };
 
-  const attributeList = React.useMemo(() => availableDevConsoleAttributes(namespace), [namespace]);
+  const attributeList = React.useMemo(
+    () => (namespace ? availableDevConsoleAttributes(namespace) : []),
+    [namespace],
+  );
 
   React.useEffect(() => {
     tenant = getInitialTenantFromNamespace(namespace);


### PR DESCRIPTION
Changes to handling the react router params in the console horizontal-nav extension, cause the `useParams` hook to return empty results.  Merging the url params that are passed as props to the component with the ones returned form `useParams` fixes the issue, and keeps backward compatibility with older console versions (4.12+).