### PR TITLE
LOG-5268: fix line filters parsing

### DIFF
--- a/web/src/__tests__/logql-query.spec.ts
+++ b/web/src/__tests__/logql-query.spec.ts
@@ -231,6 +231,48 @@ describe('LogQL query', () => {
           ],
         },
       },
+      {
+        query:
+          '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." != "10.128"',
+        expected: {
+          selectorMatchers: [{ label: 'log_type', operator: '=~', value: '".+"' }],
+          pipeline: [
+            {
+              operator: '|',
+              value: 'json',
+              labelsInFilter: undefined,
+            },
+            {
+              operator: '|',
+              value: 'level="unknown" or level=""',
+              labelsInFilter: [
+                {
+                  label: 'level',
+                  operator: '=',
+                  value: '"unknown"',
+                },
+                {
+                  label: 'level',
+                  operator: '=',
+                  value: '""',
+                },
+              ],
+            },
+            {
+              operator: '!=',
+              value: '"tekton"',
+            },
+            {
+              operator: '|=',
+              value: '"TLS handshake error from 10."',
+            },
+            {
+              operator: '!=',
+              value: '"10.128"',
+            },
+          ],
+        },
+      },
     ].forEach(({ query, expected }) => {
       const logql = new LogQLQuery(query);
       expect(logql.streamSelector).toEqual(expected.selectorMatchers);
@@ -464,6 +506,18 @@ describe('LogQL query', () => {
           'sum by (level) (count_over_time({ log_type =~ ".+" } | json | level="unknown" or level="" or level=~"emerg|fatal|alert|crit|critical|err|error|eror|warn|warning|inf|info|information|notice" [1m]))',
         expected:
           'sum by (level) (count_over_time({ log_type=~".+" } | json | level="unknown" or level="" or level=~"emerg|fatal|alert|crit|critical|err|error|eror|warn|warning|inf|info|information|notice" [1m]))',
+      },
+      {
+        query:
+          '{ log_type=~".+" } | json != "tekton" |= "TLS handshake error from 10." != "10.128"',
+        expected:
+          '{ log_type=~".+" } | json != "tekton" |= "TLS handshake error from 10." != "10.128"',
+      },
+      {
+        query:
+          '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128"',
+        expected:
+          '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128"',
       },
     ].forEach(({ query, expected }) => {
       const logql = new LogQLQuery(query);

--- a/web/src/logql-query.ts
+++ b/web/src/logql-query.ts
@@ -50,6 +50,38 @@ const parseMatchers = (
   return matchers;
 };
 
+const parseLineFilters = (
+  syntaxTree: Tree,
+  node: SyntaxNodeRef,
+  query: string,
+): Array<PipelineStage> => {
+  const lineFilters: Array<PipelineStage> = [];
+  let operator: string, value: string;
+
+  syntaxTree.iterate({
+    from: node.from,
+    to: node.to,
+    enter(selectorsNode) {
+      if (['PipeExact', 'PipeMatch', 'Eq', 'Neq', 'Re', 'Nre'].includes(selectorsNode.name)) {
+        operator = query.slice(selectorsNode.from, selectorsNode.to);
+
+        return false;
+      } else if (selectorsNode.name === 'String') {
+        value = query.slice(selectorsNode.from, selectorsNode.to);
+
+        return false;
+      }
+    },
+    leave(selectorsNode) {
+      if (selectorsNode.name === 'LineFilter') {
+        lineFilters.push({ operator, value });
+      }
+    },
+  });
+
+  return lineFilters;
+};
+
 const parsePipelineStages = (
   syntaxTree: Tree,
   node: SyntaxNodeRef,
@@ -57,16 +89,15 @@ const parsePipelineStages = (
 ): Array<PipelineStage> => {
   const pipelineStages: Array<PipelineStage> = [];
   let operator: string, value: string, labelsInFilter: Array<LabelMatcher> | undefined;
+  let lineFilters: Array<PipelineStage> = [];
 
   syntaxTree.iterate({
     from: node.from,
     to: node.to,
     enter(selectorsNode) {
-      if (selectorsNode.name === 'Pipe') {
-        operator = query.slice(selectorsNode.from, selectorsNode.to);
-
-        return false;
-      } else if (['PipeExact', 'PipeMatch', 'Nre', 'Neq'].includes(selectorsNode.name)) {
+      if (
+        ['Pipe', 'PipeExact', 'PipeMatch', 'Eq', 'Neq', 'Re', 'Nre'].includes(selectorsNode.name)
+      ) {
         operator = query.slice(selectorsNode.from, selectorsNode.to);
 
         return false;
@@ -76,6 +107,7 @@ const parsePipelineStages = (
           'JsonExpressionParser',
           'LabelFilter',
           'LineFormatExpr',
+          'LineFilters',
           'LabelFormatExpr',
           'String',
         ].includes(selectorsNode.name)
@@ -84,6 +116,8 @@ const parsePipelineStages = (
 
         if (selectorsNode.name === 'LabelFilter') {
           labelsInFilter = parseMatchers(syntaxTree, selectorsNode, query);
+        } else if (selectorsNode.name === 'LineFilters') {
+          lineFilters = parseLineFilters(syntaxTree, selectorsNode, query);
         }
 
         return false;
@@ -91,9 +125,14 @@ const parsePipelineStages = (
     },
     leave(selectorsNode) {
       if (selectorsNode.name === 'PipelineStage') {
-        pipelineStages.push({ operator, value, labelsInFilter });
-        labelsInFilter = undefined;
+        if (lineFilters.length > 0) {
+          pipelineStages.push(...lineFilters);
+        } else {
+          pipelineStages.push({ operator, value, labelsInFilter });
+        }
       }
+      labelsInFilter = undefined;
+      lineFilters = [];
     },
   });
 


### PR DESCRIPTION
This PR fixes a bug related to parsing the line filter in a LogQL expression