### PR TITLE
LOG-5287: Update the Admin > Logs page to pull the available pod list from the Loki API

### DIFF
--- a/web/src/attribute-filters.tsx
+++ b/web/src/attribute-filters.tsx
@@ -128,7 +128,30 @@ const resourceDataSource =
     return listItems.flatMap(mapper).filter(({ value }) => notEmptyString(value));
   };
 
-export const availableAttributes: AttributeList = [
+// The logs-page and the logs-dev-page both need a default set of attributes to pass
+// to queryFromFilters and filtersFromQuery which only need id and label
+export const initialAvailableAttributes: AttributeList = [
+  {
+    name: 'Namespaces',
+    label: 'kubernetes_namespace_name',
+    id: 'namespace',
+    valueType: 'checkbox-select',
+  },
+  {
+    name: 'Pods',
+    label: 'kubernetes_pod_name',
+    id: 'pod',
+    valueType: 'checkbox-select',
+  },
+  {
+    name: 'Containers',
+    label: 'kubernetes_container_name',
+    id: 'container',
+    valueType: 'checkbox-select',
+  },
+];
+
+export const availableAttributes = (tenant: string, config: Config): AttributeList => [
   {
     name: 'Content',
     id: 'content',
@@ -145,7 +168,11 @@ export const availableAttributes: AttributeList = [
     name: 'Pods',
     label: 'kubernetes_pod_name',
     id: 'pod',
-    options: resourceDataSource({ resource: 'pods' }),
+    options: lokiLabelValuesDataSource({
+      config,
+      tenant,
+      labelName: 'kubernetes_pod_name',
+    }),
     valueType: 'checkbox-select',
   },
   {
@@ -164,7 +191,7 @@ export const availableAttributes: AttributeList = [
   },
 ];
 
-export const availableDevConsoleAttributes = (namespace: string, config: Config): AttributeList => [
+export const availableDevConsoleAttributes = (tenant: string, config: Config): AttributeList => [
   {
     name: 'Content',
     id: 'content',
@@ -183,8 +210,8 @@ export const availableDevConsoleAttributes = (namespace: string, config: Config)
     id: 'pod',
     options: lokiLabelValuesDataSource({
       config,
+      tenant,
       labelName: 'kubernetes_pod_name',
-      tenant: getInitialTenantFromNamespace(namespace),
     }),
     valueType: 'checkbox-select',
   },
@@ -194,8 +221,8 @@ export const availableDevConsoleAttributes = (namespace: string, config: Config)
     id: 'container',
     options: lokiLabelValuesDataSource({
       config,
+      tenant,
       labelName: 'kubernetes_container_name',
-      tenant: getInitialTenantFromNamespace(namespace),
     }),
     valueType: 'checkbox-select',
   },

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import {
-  availableAttributes,
   availableDevConsoleAttributes,
+  initialAvailableAttributes,
   filtersFromQuery,
   queryFromFilters,
 } from '../attribute-filters';
@@ -54,7 +54,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
     interval,
     direction,
     setDirectionInURL,
-  } = useURLState({ attributes: availableAttributes, defaultTenant: tenant });
+  } = useURLState({ attributes: initialAvailableAttributes, defaultTenant: tenant });
 
   const {
     histogramData,
@@ -110,7 +110,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
 
     const updatedFilters = filtersFromQuery({
       query: queryFromInput,
-      attributes: availableAttributes,
+      attributes: initialAvailableAttributes,
     });
 
     setFilters(updatedFilters);
@@ -127,7 +127,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
       const updatedQuery = queryFromFilters({
         existingQuery: defaultQueryFromTenant(selectedTenant),
         filters: { namespace: new Set(namespace ? [namespace] : []) },
-        attributes: availableAttributes,
+        attributes: initialAvailableAttributes,
         tenant: selectedTenant,
       });
 
@@ -138,7 +138,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
       const updatedQuery = queryFromFilters({
         existingQuery: query,
         filters: selectedFilters,
-        attributes: availableAttributes,
+        attributes: initialAvailableAttributes,
         tenant: selectedTenant,
       });
 
@@ -149,7 +149,10 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
   };
 
   const attributeList = React.useMemo(
-    () => (namespace ? availableDevConsoleAttributes(namespace, config) : []),
+    () =>
+      namespace
+        ? availableDevConsoleAttributes(getInitialTenantFromNamespace(namespace), config)
+        : [],
     [namespace, config],
   );
 

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -11,7 +11,12 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { availableAttributes, filtersFromQuery, queryFromFilters } from '../attribute-filters';
+import {
+  availableAttributes,
+  initialAvailableAttributes,
+  filtersFromQuery,
+  queryFromFilters,
+} from '../attribute-filters';
 import { Filters } from '../components/filters/filter.types';
 import { LogsHistogram } from '../components/logs-histogram';
 import { LogsMetrics } from '../components/logs-metrics';
@@ -44,7 +49,7 @@ const LogsPage: React.FC = () => {
     interval,
     direction,
     setDirectionInURL,
-  } = useURLState({ attributes: availableAttributes });
+  } = useURLState({ attributes: initialAvailableAttributes });
 
   const {
     histogramData,
@@ -95,7 +100,7 @@ const LogsPage: React.FC = () => {
 
     const updatedFilters = filtersFromQuery({
       query: queryFromInput,
-      attributes: availableAttributes,
+      attributes: initialAvailableAttributes,
     });
 
     setFilters(updatedFilters);
@@ -112,7 +117,7 @@ const LogsPage: React.FC = () => {
       const updatedQuery = queryFromFilters({
         existingQuery: query,
         filters: selectedFilters,
-        attributes: availableAttributes,
+        attributes: initialAvailableAttributes,
         tenant: selectedTenant,
       });
 
@@ -121,6 +126,11 @@ const LogsPage: React.FC = () => {
       return updatedQuery;
     }
   };
+
+  const attributeList = React.useMemo(
+    () => (tenant ? availableAttributes(tenant, config) : []),
+    [tenant, config],
+  );
 
   const handleRefreshClick = () => {
     runQuery();
@@ -199,7 +209,7 @@ const LogsPage: React.FC = () => {
           showResources={areResourcesShown}
           onShowResourcesToggle={setShowResourcesInURL}
           isDisabled={isQueryEmpty}
-          attributeList={availableAttributes}
+          attributeList={attributeList}
           filters={filters}
           onFiltersChange={handleFiltersChange}
         />


### PR DESCRIPTION
This PR looks to ensure that pods which are no longer available are able to have their logs be selected as a filter. 

This does create a behavior change on the Admin > Logs filter, as before even if there were no logs for a pod it would still be displayed in the list, while now only pods which have logs will be displayed. I believe that this makes sense and will make our software easier to use, but if this isn't desired behavior, I can add in an array merge to make sure that the pods that haven't sent logs still show up to filter to.