### PR TITLE
[release-5.7] LOG-5032: backport korrel8r client to get links from alerts to logs

### DIFF
--- a/web/src/hooks/useLogActionsExtension.tsx
+++ b/web/src/hooks/useLogActionsExtension.tsx
@@ -1,7 +1,10 @@
 import { Action, Alert, ExtensionHook } from '@openshift-console/dynamic-plugin-sdk';
 import { ListIcon } from '@patternfly/react-icons';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { listGoals } from '../korrel8r-client';
+import { Korrel8rResponse } from '../korrel8r.types';
+import { LogQLQuery } from '../logql-query';
 
 type LogActionsExtensionOptions = {
   alert?: Alert;
@@ -11,21 +14,98 @@ const useLogActionsExtension: ExtensionHook<Array<Action>, LogActionsExtensionOp
   options,
 ) => {
   const { t } = useTranslation('plugin__logging-view-plugin');
+  const [actions, setActions] = React.useState<Action[]>([]);
 
-  // TODO: transform promQL into logQL
-  const alertQuery = options.alert?.rule?.query ?? '';
-  const href = `/monitoring/logs?q=${alertQuery}`;
-  const [actions] = React.useState([
-    {
-      id: 'link-to-logs',
-      label: (
-        <>
-          <ListIcon /> {t('See related logs')}
-        </>
-      ),
-      cta: { href },
-    },
-  ]);
+  const alertingRuleName = options.alert?.rule.name;
+
+  useEffect(() => {
+    if (alertingRuleName) {
+      const alertNamespace = options.alert?.labels?.namespace;
+      const alertPod = options.alert?.labels?.pod;
+      const alertContainer = options.alert?.labels?.container;
+
+      const alertQuery: Record<string, string> = { alertname: alertingRuleName };
+
+      if (alertNamespace) {
+        alertQuery.namespace = alertNamespace;
+      }
+
+      if (alertPod) {
+        alertQuery.pod = alertPod;
+      }
+
+      if (alertContainer) {
+        alertQuery.container = alertContainer;
+      }
+
+      const { request, abort } = listGoals({
+        goalsRequest: {
+          start: {
+            class: 'alert:alert',
+            queries: [`alert:alert:${JSON.stringify(alertQuery)}`],
+          },
+          goals: ['log:application', 'log:audit', 'log:infrastructure'],
+        },
+      });
+
+      request()
+        .then((response: Korrel8rResponse) => {
+          response.some((goal) => {
+            let tenant: string | undefined;
+            if (goal?.class === 'log:application') {
+              tenant = 'application';
+            } else if (goal?.class === 'log:audit') {
+              tenant = 'audit';
+            } else if (goal?.class === 'log:infrastructure') {
+              tenant = 'infrastructure';
+            }
+
+            // Use the first goal query that has results and a logQL query
+            const query = goal?.queries?.find((q) => q?.count > 0 && q?.query)?.query;
+
+            if (query && tenant) {
+              // Strip korrel8r class off the beginning of the query string
+              const logQL = query.replace(/^log:(application|audit|infrastructure):/, '');
+
+              // Add a json pipeline stage to the query
+              const parsedQuery = new LogQLQuery(logQL);
+              parsedQuery.addPipelineStage({
+                operator: '|',
+                value: 'json',
+              });
+
+              const params = new URLSearchParams();
+              params.set('q', parsedQuery.toString());
+              params.set('tenant', tenant);
+              const href = `/monitoring/logs?${params.toString()}`;
+
+              setActions([
+                {
+                  id: 'link-to-logs',
+                  label: (
+                    <>
+                      <ListIcon /> {t('See related logs')}
+                    </>
+                  ),
+                  cta: { href },
+                },
+              ]);
+
+              // Exit early (ignore any remaining goals)
+              return true;
+            }
+          });
+        })
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.warn('Error fetching korrel8r goals: ', error);
+        });
+
+      return () => {
+        abort();
+      };
+    }
+  }, [alertingRuleName]);
 
   return [actions, true, null];
 };

--- a/web/src/korrel8r-client.ts
+++ b/web/src/korrel8r-client.ts
@@ -1,0 +1,40 @@
+import { cancellableFetch, RequestInitWithTimeout } from './cancellable-fetch';
+import { GoalsRequest, Korrel8rResponse } from './korrel8r.types';
+import { Config } from './logs.types';
+
+const KORREL8R_ENDPOINT = '/api/proxy/plugin/logging-view-plugin/korrel8r';
+
+export const getFetchConfig = ({
+  config,
+}: {
+  config?: Config;
+}): { requestInit?: RequestInitWithTimeout; endpoint: string } => {
+  return {
+    requestInit: {
+      timeout: config?.timeout ? config.timeout * 1000 : undefined,
+    },
+    endpoint: KORREL8R_ENDPOINT,
+  };
+};
+
+export const listGoals = ({
+  config,
+  goalsRequest,
+}: {
+  config?: Config;
+  goalsRequest: GoalsRequest;
+}) => {
+  const { endpoint, requestInit } = getFetchConfig({ config });
+
+  const requestData = { ...requestInit, method: 'POST', body: JSON.stringify(goalsRequest) };
+
+  return cancellableFetch<Korrel8rResponse>(`${endpoint}/api/v1alpha1/lists/goals`, requestData);
+};
+
+export const listDomains = ({ config }: { config?: Config } = {}) => {
+  const { endpoint, requestInit } = getFetchConfig({ config });
+
+  const requestData = { ...requestInit, method: 'GET' };
+
+  return cancellableFetch<Korrel8rResponse>(`${endpoint}/api/v1alpha1/domains`, requestData);
+};

--- a/web/src/korrel8r.types.ts
+++ b/web/src/korrel8r.types.ts
@@ -1,0 +1,20 @@
+export type Node = {
+  class: string;
+  count: number;
+  queries?: Array<{
+    count: number;
+    query: string;
+  }>;
+};
+
+export type Start = {
+  class: string;
+  queries: string[];
+};
+
+export type GoalsRequest = {
+  goals: Array<string>;
+  start: Start;
+};
+
+export type Korrel8rResponse = Array<Node>;


### PR DESCRIPTION
This PR backports the korrel8r client so it can be used to get links from alerts to logs