### PR TITLE
OU-456: Add CSRF header on POST requests to avoid proxy filter

### DIFF
--- a/web/src/cancellable-fetch.ts
+++ b/web/src/cancellable-fetch.ts
@@ -11,6 +11,20 @@ class TimeoutError extends Error {
   }
 }
 
+const getCSRFToken = () => {
+  const cookiePrefix = 'csrf-token=';
+  return (
+    document &&
+    document.cookie &&
+    document.cookie
+      .split(';')
+      .map((c) => c.trim())
+      .filter((c) => c.startsWith(cookiePrefix))
+      .map((c) => c.slice(cookiePrefix.length))
+      .pop()
+  );
+};
+
 class FetchError extends Error {
   status: number;
   name: string;
@@ -34,7 +48,11 @@ export const cancellableFetch = <T>(
 
   const fetchPromise = fetch(url, {
     ...init,
-    headers: { ...init?.headers, Accept: 'application/json' },
+    headers: {
+      ...init?.headers,
+      Accept: 'application/json',
+      ...(init?.method === 'POST' ? { 'X-CSRFToken': getCSRFToken() } : {}),
+    },
     signal: abortController.signal,
   }).then(async (response) => {
     if (!response.ok) {


### PR DESCRIPTION
The `ConsolePlugin.Proxy.Spec` requires the CSRF value to be present in both the cookie and the header for POST requests. This PR applies the cookie value into the header on all outbound POST requests. 

As of now the only POST request is the single korrel8r API endpoint.  However, we are making this change to all possible POST requests for now to proactively prevent the header from being missed if either korrel8r or the logging proxies end up needing further POST requests in the future.
