### PR TITLE
LOG-5761: Add support LogQL pattern line filters

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "logging-view-plugin",
       "version": "0.0.1",
       "dependencies": {
-        "@grafana/lezer-logql": "^0.1.1",
+        "@grafana/lezer-logql": "^0.2.6",
         "@patternfly/patternfly": "4.215.1",
         "@patternfly/react-charts": "6.92.0",
         "@patternfly/react-core": "4.239.0",
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/@grafana/lezer-logql": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@grafana/lezer-logql/-/lezer-logql-0.1.1.tgz",
-      "integrity": "sha512-3iI4f6zXgdFy6rjPKK0tX5s9aDVu08TYXdgs0qm2Pwz7dbixyTa0ec7mK8+DScUhiT6M/+ycSMlKprPKlCL8+w==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@grafana/lezer-logql/-/lezer-logql-0.2.6.tgz",
+      "integrity": "sha512-XGTvLEzbKVCi/Y7li1fOYrihQqJhQ1Q2Qopj0Dix850TDnjtmK/V20js+ZA0bd+I0TiRyFYvMDLMwiUVMjzmCg==",
       "peerDependencies": {
         "@lezer/lr": "^1.0.0"
       }
@@ -19096,9 +19096,9 @@
       "dev": true
     },
     "@grafana/lezer-logql": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@grafana/lezer-logql/-/lezer-logql-0.1.1.tgz",
-      "integrity": "sha512-3iI4f6zXgdFy6rjPKK0tX5s9aDVu08TYXdgs0qm2Pwz7dbixyTa0ec7mK8+DScUhiT6M/+ycSMlKprPKlCL8+w==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@grafana/lezer-logql/-/lezer-logql-0.2.6.tgz",
+      "integrity": "sha512-XGTvLEzbKVCi/Y7li1fOYrihQqJhQ1Q2Qopj0Dix850TDnjtmK/V20js+ZA0bd+I0TiRyFYvMDLMwiUVMjzmCg==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/web/package.json
+++ b/web/package.json
@@ -101,7 +101,7 @@
     }
   },
   "dependencies": {
-    "@grafana/lezer-logql": "^0.1.1",
+    "@grafana/lezer-logql": "^0.2.6",
     "@patternfly/patternfly": "4.215.1",
     "@patternfly/react-charts": "6.92.0",
     "@patternfly/react-core": "4.239.0",

--- a/web/src/__tests__/logql-query.spec.ts
+++ b/web/src/__tests__/logql-query.spec.ts
@@ -519,6 +519,14 @@ describe('LogQL query', () => {
         expected:
           '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128"',
       },
+      {
+        query: '{ app="foobar" } |> "I <_>" | json',
+        expected: '{ app="foobar" } |> "I <_>" | json',
+      },
+      {
+        query: '{ app="foobar" } !> "I <_>" | json',
+        expected: '{ app="foobar" } !> "I <_>" | json',
+      },
     ].forEach(({ query, expected }) => {
       const logql = new LogQLQuery(query);
       expect(logql.toString()).toEqual(expected);

--- a/web/src/logql-query.ts
+++ b/web/src/logql-query.ts
@@ -62,7 +62,11 @@ const parseLineFilters = (
     from: node.from,
     to: node.to,
     enter(selectorsNode) {
-      if (['PipeExact', 'PipeMatch', 'Eq', 'Neq', 'Re', 'Nre'].includes(selectorsNode.name)) {
+      if (
+        ['PipeExact', 'PipeMatch', 'PipePattern', 'Npa', 'Eq', 'Neq', 'Re', 'Nre'].includes(
+          selectorsNode.name,
+        )
+      ) {
         operator = query.slice(selectorsNode.from, selectorsNode.to);
 
         return false;


### PR DESCRIPTION
Adds support for Loki 3.x pattern line filters `|>` and `!>` such us:
```
{ log_type="application" }  |> "I <_>"| json
```

and

```
{ log_type="application" }  !> "I <_>"| json
```

Follow up on testing of:
- https://github.com/observatorium/api/pull/723

Depends on:
- https://github.com/grafana/lezer-logql/pull/63