### PR TITLE
OU-483: Add the Volume API to the Logging-View-Plugin

### DIFF
--- a/hack/docker-compose/docker-compose.test.yml
+++ b/hack/docker-compose/docker-compose.test.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.8.0
+    image: grafana/loki:3.1.0
     ports:
       - 3200:3100
     restart: unless-stopped

--- a/hack/docker-compose/loki/loki-config.yml
+++ b/hack/docker-compose/loki/loki-config.yml
@@ -35,6 +35,8 @@ limits_config:
   enforce_metric_name: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
+  volume_enabled: true
+  volume_max_series: 1000
 
 ruler:
   storage:

--- a/web/cypress/fixtures/query-range-fixtures.ts
+++ b/web/cypress/fixtures/query-range-fixtures.ts
@@ -443,3 +443,172 @@ export const queryRangeStreamsWithMessage = () => {
     },
   };
 };
+
+export const volumeRangeMatrixValidResponse = () => {
+  const startTime = Math.floor((Date.now() - 1000 * 60 * 60) / 1000);
+  return{
+    status: "success",
+    data: {
+      resultType: "matrix",
+      result: [
+        {
+          metric: {
+            level: "info"
+          },
+          values: generateMatrixValues({ nValues: 20, startTime }),
+        }
+      ],
+      "stats": {
+        "summary": {
+            "bytesProcessedPerSecond": 0,
+            "linesProcessedPerSecond": 0,
+            "totalBytesProcessed": 0,
+            "totalLinesProcessed": 0,
+            "execTime": 0.038628073,
+            "queueTime": 0,
+            "subqueries": 0,
+            "totalEntriesReturned": 1,
+            "splits": 251,
+            "shards": 0,
+            "totalPostFilterLines": 0,
+            "totalStructuredMetadataBytesProcessed": 0
+        },
+        "querier": {
+            "store": {
+                "totalChunksRef": 0,
+                "totalChunksDownloaded": 0,
+                "chunksDownloadTime": 0,
+                "queryReferencedStructuredMetadata": false,
+                "chunk": {
+                    "headChunkBytes": 0,
+                    "headChunkLines": 0,
+                    "decompressedBytes": 0,
+                    "decompressedLines": 0,
+                    "compressedBytes": 0,
+                    "totalDuplicates": 0,
+                    "postFilterLines": 0,
+                    "headChunkStructuredMetadataBytes": 0,
+                    "decompressedStructuredMetadataBytes": 0
+                },
+                "chunkRefsFetchTime": 0,
+                "congestionControlLatency": 0,
+                "pipelineWrapperFilteredLines": 0
+            }
+        },
+        "ingester": {
+            "totalReached": 0,
+            "totalChunksMatched": 0,
+            "totalBatches": 0,
+            "totalLinesSent": 0,
+            "store": {
+                "totalChunksRef": 0,
+                "totalChunksDownloaded": 0,
+                "chunksDownloadTime": 0,
+                "queryReferencedStructuredMetadata": false,
+                "chunk": {
+                    "headChunkBytes": 0,
+                    "headChunkLines": 0,
+                    "decompressedBytes": 0,
+                    "decompressedLines": 0,
+                    "compressedBytes": 0,
+                    "totalDuplicates": 0,
+                    "postFilterLines": 0,
+                    "headChunkStructuredMetadataBytes": 0,
+                    "decompressedStructuredMetadataBytes": 0
+                },
+                "chunkRefsFetchTime": 0,
+                "congestionControlLatency": 0,
+                "pipelineWrapperFilteredLines": 0
+            }
+        },
+        "cache": {
+            "chunk": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "index": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "result": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "statsResult": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "volumeResult": {
+                "entriesFound": 13,
+                "entriesRequested": 13,
+                "entriesStored": 5,
+                "bytesReceived": 17069,
+                "bytesSent": 0,
+                "requests": 18,
+                "downloadTime": 216375,
+                "queryLengthServed": 2903000000000
+            },
+            "seriesResult": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "labelResult": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            },
+            "instantMetricResult": {
+                "entriesFound": 0,
+                "entriesRequested": 0,
+                "entriesStored": 0,
+                "bytesReceived": 0,
+                "bytesSent": 0,
+                "requests": 0,
+                "downloadTime": 0,
+                "queryLengthServed": 0
+            }
+        },
+        "index": {
+            "totalChunks": 0,
+            "postFilterChunks": 0,
+            "shardsDuration": 0
+        }
+      }
+    }
+  }
+};

--- a/web/cypress/integration/logs-page.cy.ts
+++ b/web/cypress/integration/logs-page.cy.ts
@@ -7,6 +7,7 @@ import {
   queryRangeStreamsValidResponse,
   queryRangeStreamsWithLineFormatting,
   queryRangeStreamsWithMessage,
+  volumeRangeMatrixValidResponse,
 } from '../fixtures/query-range-fixtures';
 import { namespaceListResponse } from '../fixtures/resource-api-fixtures';
 import { formatTimeRange } from '../../src/time-range';
@@ -21,6 +22,8 @@ const QUERY_RANGE_STREAMS_INFRASTRUCTURE_URL_MATCH =
   '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure/loki/api/v1/query_range?query=%7B*';
 const QUERY_RANGE_MATRIX_INFRASTRUCTURE_URL_MATCH =
   '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure/loki/api/v1/query_range?query=sum*';
+const VOLUME_QUERY_URL_MATCH =
+  '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application/loki/api/v1/index/volume_range?query=*';
 const CONFIG_URL_MATCH = '/api/plugins/logging-view-plugin/config';
 const RESOURCE_URL_MATCH = '/api/kubernetes/api/v1/*';
 const TEST_MESSAGE = "loki_1 | level=info msg='test log'";
@@ -61,6 +64,25 @@ describe('Logs Page', () => {
       });
   });
     
+  it('tests if the volume graph is enabled and is viewable', () => {
+    cy.intercept(
+      QUERY_RANGE_STREAMS_URL_MATCH,
+      queryRangeStreamsValidResponse({ message: TEST_MESSAGE }),
+    ).as('queryRangeStreams');
+
+    cy.intercept(VOLUME_QUERY_URL_MATCH, volumeRangeMatrixValidResponse()).as('volumeRangeMatrix');
+
+    cy.visit(LOGS_PAGE_URL);
+
+    cy.getByTestId(TestIds.ExecuteQueryButton).click();
+
+    cy.getByTestId(TestIds.LogsTable).should('exist');
+
+    cy.getByTestId(TestIds.ExecuteVolumeButton).click();
+    
+    cy.getByTestId(TestIds.LogsMetrics).should('exist');
+  });
+
   it('tests if the stats table is enabled and is viewable', () => {
     cy.intercept(
       QUERY_RANGE_STREAMS_URL_MATCH,

--- a/web/locales/en/plugin__logging-view-plugin.json
+++ b/web/locales/en/plugin__logging-view-plugin.json
@@ -69,6 +69,8 @@
   "Hide Stats": "Hide Stats",
   "Show Query": "Show Query",
   "Hide Query": "Hide Query",
+  "Explain Log Volume" : "Explain Log Volume",
+  "Gives the volume of data for the given stream selector": "Gives the volume of data for the given stream selector",
   "Invalid time format": "Invalid time format",
   "Refresh off": "Refresh off",
   "15 seconds": "15 seconds",

--- a/web/src/components/execute-volume-button.tsx
+++ b/web/src/components/execute-volume-button.tsx
@@ -1,0 +1,21 @@
+import { Button, ButtonProps, Tooltip } from '@patternfly/react-core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TestIds } from '../test-ids';
+
+export const ExecuteVolumeButton: React.FC<ButtonProps> = ({ onClick, isDisabled }) => {
+  const { t } = useTranslation('plugin__logging-view-plugin');
+
+  return (
+    <Tooltip content={t('Gives the volume of data for the given stream selector')}>
+      <Button
+        variant="secondary"
+        data-test={TestIds.ExecuteVolumeButton}
+        onClick={onClick}
+        isDisabled={isDisabled}
+      >
+        {t('Explain Log Volume')}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -199,8 +199,8 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
             themeColor={ChartThemeColor.multiUnordered}
             padding={{
               bottom: 40,
-              left: 65,
-              right: 10,
+              left: 100,
+              right: 20,
               top: 10,
             }}
             domainPadding={{ x: [30, 25] }}
@@ -225,7 +225,7 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
           </Chart>
           {displayLegendTable && (
             <InnerScrollContainer>
-              <Table variant="compact">
+              <Table variant="compact" aria-label="alert metrics">
                 <Thead>
                   <Tr>
                     <Th isStickyColumn stickyMinWidth="20px" style={{ width: '20px' }}></Th>

--- a/web/src/components/logs-query-input.css
+++ b/web/src/components/logs-query-input.css
@@ -12,3 +12,7 @@ textarea.pf-c-form-control.co-logs-expression-input__searchInput {
   font-family: var(--pf-c-code-block__pre--FontFamily), monospace;
   font-size: var(--pf-c-code-block__pre--FontSize);
 }
+
+.co-logs-expression-input__volumeButton{
+  margin-left: var(--pf-global--spacer--md);
+}

--- a/web/src/components/logs-query-input.tsx
+++ b/web/src/components/logs-query-input.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { LogQLQuery } from '../logql-query';
 import { TestIds } from '../test-ids';
 import { ExecuteQueryButton } from './execute-query-button';
+import { ExecuteVolumeButton } from './execute-volume-button';
 import './logs-query-input.css';
 
 interface LogsQueryInputProps {
   value: string;
   onChange?: (expression: string) => void;
   onRun?: () => void;
+  onVolumeRun?: () => void;
   isDisabled?: boolean;
   invalidQueryErrorMessage?: string | null;
 }
@@ -18,6 +20,7 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
   value = '',
   onChange,
   onRun,
+  onVolumeRun,
   isDisabled,
   invalidQueryErrorMessage,
 }) => {
@@ -82,6 +85,14 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
           isDisabled={value === undefined || value.length === 0 || isDisabled}
         />
       )}
+      <div className="co-logs-expression-input__volumeButton">
+        {onVolumeRun && (
+          <ExecuteVolumeButton
+            onClick={onVolumeRun}
+            isDisabled={value === undefined || value.length === 0 || isDisabled}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -17,6 +17,7 @@ import { Severity, severityFromString } from '../severity';
 import { TestIds } from '../test-ids';
 import { notUndefined } from '../value-utils';
 import { ExecuteQueryButton } from './execute-query-button';
+import { ExecuteVolumeButton } from './execute-volume-button';
 import { AttributeFilter } from './filters/attribute-filter';
 import { AttributeList, Filters } from './filters/filter.types';
 import { LogsQueryInput } from './logs-query-input';
@@ -30,6 +31,7 @@ interface LogsToolbarProps {
   query: string;
   onQueryChange?: (query: string) => void;
   onQueryRun?: () => void;
+  onVolumeRun?: () => void;
   invalidQueryErrorMessage?: string | null;
   tenant?: string;
   onTenantSelect?: (tenant: string) => void;
@@ -63,6 +65,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   query,
   onQueryChange,
   onQueryRun,
+  onVolumeRun,
   invalidQueryErrorMessage,
   tenant = 'application',
   onTenantSelect,
@@ -198,6 +201,9 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             <ToolbarGroup>
               <ExecuteQueryButton onClick={onQueryRun} isDisabled={isDisabled} />
             </ToolbarGroup>
+            <ToolbarGroup>
+              <ExecuteVolumeButton onClick={onVolumeRun} isDisabled={isDisabled} />
+            </ToolbarGroup>
             {invalidQueryErrorMessage && (
               <ToolbarGroup>
                 <Alert variant="danger" isInline isPlain title={invalidQueryErrorMessage} />
@@ -229,6 +235,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
         <LogsQueryInput
           value={query}
           onRun={onQueryRun}
+          onVolumeRun={onVolumeRun}
           onChange={onQueryChange}
           invalidQueryErrorMessage={invalidQueryErrorMessage}
           isDisabled={isDisabled}

--- a/web/src/logs.types.ts
+++ b/web/src/logs.types.ts
@@ -65,6 +65,8 @@ export type QueryRangeResponse<T = MatrixResult | StreamsResult> = {
   };
 };
 
+export type VolumeRangeResponse = QueryRangeResponse<MatrixResult>;
+
 export type Rule = {
   query?: string;
   labels?: Record<string, string>;

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -6,6 +6,7 @@ import {
   Direction,
   LabelValueResponse,
   QueryRangeResponse,
+  VolumeRangeResponse,
   RulesResponse,
 } from './logs.types';
 import { durationFromTimestamp } from './value-utils';
@@ -20,6 +21,16 @@ type QueryRangeParams = {
   namespace?: string;
   tenant: string;
   direction?: Direction;
+};
+
+type VolumeRangeParams = {
+  query: string;
+  start: number;
+  end: number;
+  config?: Config;
+  namespace?: string;
+  tenant: string;
+  targetLabels?: string;
 };
 
 type HistogramQuerParams = {
@@ -122,6 +133,33 @@ export const executeQueryRange = ({
 
   return cancellableFetch<QueryRangeResponse>(
     `${endpoint}/loki/api/v1/query_range?${new URLSearchParams(params)}`,
+    requestInit,
+  );
+};
+
+export const executeVolumeRange = ({
+  query,
+  start,
+  end,
+  config,
+  tenant,
+  namespace,
+}: VolumeRangeParams): CancellableFetch<VolumeRangeResponse> => {
+  const extendedQuery = queryWithNamespace({
+    query,
+    namespace,
+  });
+
+  const params: Record<string, string> = {
+    query: extendedQuery,
+    start: String(start * 1000000),
+    end: String(end * 1000000),
+  };
+
+  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+
+  return cancellableFetch<VolumeRangeResponse>(
+    `${endpoint}/loki/api/v1/index/volume_range?${new URLSearchParams(params)}`,
     requestInit,
   );
 };

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -63,6 +63,11 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
     getMoreLogs,
     hasMoreLogsData,
     toggleStreaming,
+    getVolume,
+    volumeData,
+    isLoadingVolumeData,
+    volumeError,
+    showVolumeGraph,
     getHistogram,
     histogramData,
     isLoadingHistogramData,
@@ -116,6 +121,10 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
     if (isHistogramVisible) {
       getHistogram({ query, tenant: tenant.current, namespace, timeRange });
     }
+  };
+
+  const runVolume = () => {
+    getVolume({ query, tenant: tenant.current, namespace, timeRange });
   };
 
   const handleFiltersChange = (selectedFilters?: Filters) => {
@@ -206,6 +215,7 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
           query={query}
           onQueryChange={handleQueryChange}
           onQueryRun={runQuery}
+          onVolumeRun={runVolume}
           isStreaming={isStreaming}
           onStreamingToggle={handleToggleStreaming}
           showResources={areResourcesShown}
@@ -222,6 +232,19 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
 
         {isLoadingLogsData ? (
           <CenteredContainer>{t('Loading...')}</CenteredContainer>
+        ) : showVolumeGraph ? (
+          <Card>
+            <CardBody>
+              <LogsMetrics
+                logsData={volumeData}
+                timeRange={timeRange}
+                isLoading={isLoadingVolumeData}
+                error={volumeError}
+                height={350}
+                displayLegendTable
+              />
+            </CardBody>
+          </Card>
         ) : resultIsMetric ? (
           <Card>
             <CardBody>

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -67,7 +67,12 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
     isStreaming,
     logsData,
     logsError,
+    volumeData,
+    isLoadingVolumeData,
+    volumeError,
+    showVolumeGraph,
     getLogs,
+    getVolume,
     getMoreLogs,
     hasMoreLogsData,
     getHistogram,
@@ -100,6 +105,10 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
     if (isHistogramVisible) {
       getHistogram({ query: queryToUse ?? query, timeRange, tenant });
     }
+  };
+
+  const runVolume = () => {
+    getVolume({ query, tenant, namespace, timeRange });
   };
 
   const handleFiltersChange = (selectedFilters?: Filters) => {
@@ -236,6 +245,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
           query={query}
           onQueryChange={handleQueryChange}
           onQueryRun={runQuery}
+          onVolumeRun={runVolume}
           invalidQueryErrorMessage={
             isNamespaceFilterEmpty ? t('Please select a namespace') : undefined
           }
@@ -255,6 +265,19 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
 
         {isLoadingLogsData ? (
           <CenteredContainer>{t('Loading...')}</CenteredContainer>
+        ) : showVolumeGraph ? (
+          <Card>
+            <CardBody>
+              <LogsMetrics
+                logsData={volumeData}
+                timeRange={timeRange}
+                isLoading={isLoadingVolumeData}
+                error={volumeError}
+                height={350}
+                displayLegendTable
+              />
+            </CardBody>
+          </Card>
         ) : resultIsMetric ? (
           <Card>
             <CardBody>

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -59,10 +59,15 @@ const LogsPage: React.FC = () => {
     isLoadingLogsData,
     isLoadingMoreLogsData,
     isLoadingHistogramData,
+    isLoadingVolumeData,
+    volumeError,
+    showVolumeGraph,
     isStreaming,
     logsData,
+    volumeData,
     logsError,
     getLogs,
+    getVolume,
     getMoreLogs,
     hasMoreLogsData,
     getHistogram,
@@ -90,6 +95,10 @@ const LogsPage: React.FC = () => {
     if (isHistogramVisible) {
       getHistogram({ query: queryToUse ?? query, tenant, timeRange });
     }
+  };
+
+  const runVolume = () => {
+    getVolume({ query, tenant, timeRange });
   };
 
   const handleFiltersChange = (selectedFilters?: Filters) => {
@@ -202,6 +211,7 @@ const LogsPage: React.FC = () => {
           query={query}
           onQueryChange={handleQueryChange}
           onQueryRun={runQuery}
+          onVolumeRun={runVolume}
           onTenantSelect={setTenantInURL}
           tenant={tenant}
           isStreaming={isStreaming}
@@ -219,6 +229,19 @@ const LogsPage: React.FC = () => {
 
         {isLoadingLogsData ? (
           <CenteredContainer>{t('Loading...')}</CenteredContainer>
+        ) : showVolumeGraph ? (
+          <Card>
+            <CardBody>
+              <LogsMetrics
+                logsData={volumeData}
+                timeRange={timeRange}
+                isLoading={isLoadingVolumeData}
+                error={volumeError}
+                height={350}
+                displayLegendTable
+              />
+            </CardBody>
+          </Card>
         ) : resultIsMetric ? (
           <Card>
             <CardBody>

--- a/web/src/test-ids.ts
+++ b/web/src/test-ids.ts
@@ -7,6 +7,7 @@ export enum TestIds {
   LogsMetrics = 'LogsMetrics',
   LogsQueryInput = 'LogsQueryInput',
   ExecuteQueryButton = 'ExecuteQueryButton',
+  ExecuteVolumeButton = 'ExecuteVolumeButton',
   TenantDropdown = 'TenantDropdown',
   SeverityDropdown = 'SeverityDropdown',
   ToogleStreamingButton = 'ToogleStreamingButton',


### PR DESCRIPTION
Currently the logging-view-plugin does not have the ability for the user to view [the Loki Volume API](https://grafana.com/docs/loki/next/reference/loki-http-api/#query-log-volume). This PR is to address this by creating a graph within the logging-view-plugin to allow users to have a view of the volume of logs before they run a query.
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/5b98c566-eadd-4643-b674-2e59c0fbecb2">