### PR TITLE
OU-446: Support FIPS

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -28,7 +28,7 @@ RUN make install-frontend-ci
 COPY web/ ${HOME}/web
 RUN make build-frontend
 
-FROM registry.redhat.io/ubi9/go-toolset:1.19 as go-builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -42,9 +42,12 @@ COPY config/ config/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN make build-backend
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 
-FROM registry.redhat.io/ubi9/ubi-minimal
+RUN make build-backend BUILD_OPTS="-tags strictfipsruntime"
+
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 
 USER 1001
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN make install-frontend-ci-clean
 COPY web/ web/
 RUN make build-frontend
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as go-builder
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17 as go-builder
 
 WORKDIR /opt/app-root
 
@@ -25,12 +25,9 @@ COPY config/ config/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-ENV GOEXPERIMENT=strictfipsruntime
-ENV CGO_ENABLED=1
+RUN make build-backend
 
-RUN make build-backend BUILD_OPTS="-tags strictfipsruntime"
-
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist
 COPY --from=go-builder /opt/app-root/plugin-backend /opt/app-root

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build -mod=readonly -o plugin-backend cmd/plugin-backend.go
+	go build $(BUILD_OPTS) -mod=readonly -o plugin-backend -mod=readonly cmd/plugin-backend.go
 
 .PHONY: test-unit-backend
 test-unit-backend:
@@ -52,7 +52,7 @@ start-console:
 install: install-backend build-backend install-frontend
 
 .PHONY: start-frontend
-start-frontend: 
+start-frontend:
 	cd web && npm run dev
 
 .PHONY: start-backend

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/logging-view-plugin
 
-go 1.20
+go 1.22.5
 
 require (
 	github.com/evanphx/json-patch v5.6.0+incompatible

--- a/scripts/image.sh
+++ b/scripts/image.sh
@@ -17,7 +17,7 @@ BASE_IMAGE="quay.io/${REGISTRY_ORG}/logging-view-plugin"
 IMAGE=${BASE_IMAGE}:${TAG}
 
 echo "Building image '${IMAGE}' with ${OCI_BIN}"
-$OCI_BIN build -t $IMAGE .
+$OCI_BIN build -t $IMAGE -f Dockerfile.dev .
 
 if [[ $PUSH == 1 ]]; then
     echo "Pushing to registry with ${OCI_BIN}"


### PR DESCRIPTION
This PR looks to add FIPS support to the logging-view-plugin. It updates the go version to 1.22, and uses recommended FIPS compliant images and tags. Due to some of the recommended images not being available publicly a Dockerfile.dev is added to the repo as a way to build and test images locally.