### PR TITLE
Fix Refresh Button to Follow PatternFly Guidelines

### DIFF
--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -191,7 +191,7 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
               <Button
                 onClick={runQuery}
                 aria-label="Refresh"
-                variant="primary"
+                variant="secondary"
                 data-test={TestIds.SyncButton}
               >
                 <SyncAltIcon />

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -220,7 +220,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
               <Button
                 onClick={handleRefreshClick}
                 aria-label="Refresh"
-                variant="primary"
+                variant="secondary"
                 data-test={TestIds.SyncButton}
                 isDisabled={isRunQueryDisabled}
               >

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -187,7 +187,7 @@ const LogsPage: React.FC = () => {
               <Button
                 onClick={handleRefreshClick}
                 aria-label="Refresh"
-                variant="primary"
+                variant="secondary"
                 data-test={TestIds.SyncButton}
                 isDisabled={isQueryEmpty}
               >


### PR DESCRIPTION
Currently, the refresh button in the logging-view-plugin doesn't follow PatternFly guidelines since it's a primary button which conflicts with the `Run Query` button. According to PatternFly, there can only be one primary button on a page. This PR is to address that.
<img width="2168" alt="Screenshot 2024-08-22 at 11 04 51 AM" src="https://github.com/user-attachments/assets/c8bdd5b2-66db-46fc-93ae-caff01e891ef">
