### PR TITLE
COO-301: Prevent korrel8r link from showing when Non-Admin

### DIFF
--- a/web/mockModules/dummy.tsx
+++ b/web/mockModules/dummy.tsx
@@ -3,3 +3,4 @@ export { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/w
 
 export const useK8sWatchResource = () => [null, true, ''];
 export const useActivePerspective = () => ['admin'];
+export const useAccessReview = () => [true, false];


### PR DESCRIPTION
The console codebase follows a specific service + port combination to forward low-permission users to retrieve prometheus results. Korrel8r isn't set up with regards to this, as it operates at a full cluster level, so this PR looks to remove links which won't work for low permission users.

Low Permission User:
![image](https://github.com/user-attachments/assets/8a89c932-70d4-40da-88cc-ea434c23f4d4)

Kubeadmin
![image](https://github.com/user-attachments/assets/aa95db04-cdea-4d06-a5bd-6efbc7488cf3)
