### PR TITLE
OCPBUGS-45945: split large histogram queries into multiple small sub queries

### DIFF
--- a/web/src/cancellable-fetch.ts
+++ b/web/src/cancellable-fetch.ts
@@ -46,33 +46,35 @@ export const cancellableFetch = <T>(
   const abortController = new AbortController();
   const abort = () => abortController.abort();
 
-  const fetchPromise = fetch(url, {
-    ...init,
-    headers: {
-      ...init?.headers,
-      Accept: 'application/json',
-      ...(init?.method === 'POST' ? { 'X-CSRFToken': getCSRFToken() } : {}),
-    },
-    signal: abortController.signal,
-  }).then(async (response) => {
-    if (!response.ok) {
-      const text = await response.text();
-      throw new FetchError(text, response.status);
-    }
-    return response.json();
-  });
+  const fetchPromise = () =>
+    fetch(url, {
+      ...init,
+      headers: {
+        ...init?.headers,
+        Accept: 'application/json',
+        ...(init?.method === 'POST' ? { 'X-CSRFToken': getCSRFToken() } : {}),
+      },
+      signal: abortController.signal,
+    }).then(async (response) => {
+      if (!response.ok) {
+        const text = await response.text();
+        throw new FetchError(text, response.status);
+      }
+      return response.json();
+    });
 
   const timeout = init?.timeout ?? 30 * 1000;
 
   if (timeout <= 0) {
-    return { request: () => fetchPromise, abort };
+    return { request: fetchPromise, abort };
   }
 
-  const timeoutPromise = new Promise<T>((_resolve, reject) => {
-    setTimeout(() => reject(new TimeoutError(url.toString(), timeout)), timeout);
-  });
+  const timeoutPromise = () =>
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new TimeoutError(url.toString(), timeout)), timeout);
+    });
 
-  const request = () => Promise.race([fetchPromise, timeoutPromise]);
+  const request = () => Promise.race([fetchPromise(), timeoutPromise()]);
 
   return { request, abort };
 };

--- a/web/src/components/logs-histogram.tsx
+++ b/web/src/components/logs-histogram.tsx
@@ -104,19 +104,29 @@ const metricValueToChartData = (
   group: Severity,
   value: Array<MetricValue>,
   interval: number,
-): Array<ChartData> =>
-  value.map((metric) => {
+): Array<ChartData> => {
+  const timeEntries = new Set<number>();
+  const chartData: Array<ChartData> = [];
+
+  for (const metric of value) {
     const time = parseFloat(String(metric[0])) * 1000;
     const formattedTime = dateToFormat(time, getTimeFormatFromInterval(interval));
 
-    return {
-      x: time,
-      y: parseInt(String(metric[1]), 10),
-      name: group,
-      time: formattedTime,
-      label: `${formattedTime} ${group}: ${metric[1]}`,
-    };
-  });
+    // Prevent duplicate entries to avoid chart rendering issues
+    if (!timeEntries.has(time)) {
+      timeEntries.add(time);
+      chartData.push({
+        x: time,
+        y: parseInt(String(metric[1]), 10),
+        name: group,
+        time: formattedTime,
+        label: `${formattedTime} ${group}: ${metric[1]}`,
+      });
+    }
+  }
+
+  return chartData;
+};
 
 const getChartsData = (data: HistogramData, interval: number): HistogramChartData => {
   const chartsData: HistogramChartData = {} as HistogramChartData;


### PR DESCRIPTION
This PR splits histogram queries into smaller sub queries by dividing the total time range.