### PR TITLE
NO-JIRA: PF6 Upgrade

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.6",
-        "@patternfly/patternfly": "4.215.1",
-        "@patternfly/react-charts": "6.92.0",
-        "@patternfly/react-core": "4.239.0",
-        "@patternfly/react-icons": "^4.57.2",
-        "@patternfly/react-table": "4.108.0",
+        "@patternfly/patternfly": "^5.4.2",
+        "@patternfly/react-charts": "^6.94.21",
+        "@patternfly/react-core": "^5.4.12",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-table": "^5.4.13",
         "i18next": "^22.4.12",
         "react-i18next": "^11.18.6"
       },
@@ -3302,67 +3302,76 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "4.215.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.215.1.tgz",
-      "integrity": "sha512-coOipHiQs92OYYO+pWfukEKOkY+VUL6ptusTxh98DvIu/tQYzJDJxEmzYXmwqxORM19oLxAJEGktPoLNKElj6A=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
+      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "6.92.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.92.0.tgz",
-      "integrity": "sha512-aQl+L7zH/tWX00L2xI6B0414xweaIocR98wbyhXLi6zknkhcAUcE2zITFIW4+EsU+qPvUlptwRiRufoH8/BlEw==",
+      "version": "6.94.21",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.21.tgz",
+      "integrity": "sha512-/okakDxebgSacl9gnIifMjqLMGwuwqXogEIDX+TFveIGx9BBhXg+RLnSpSZS8xQMjEcSVppdz320IN2o+YgpaQ==",
       "dependencies": {
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
+        "@patternfly/react-styles": "^4.92.8",
+        "@patternfly/react-tokens": "^4.94.7",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0",
-        "victory-area": "^36.2.1",
-        "victory-axis": "^36.2.1",
-        "victory-bar": "^36.2.1",
-        "victory-chart": "^36.2.1",
-        "victory-core": "^36.2.1",
-        "victory-create-container": "^36.2.1",
-        "victory-cursor-container": "^36.2.1",
-        "victory-group": "^36.2.1",
-        "victory-legend": "^36.2.1",
-        "victory-line": "^36.2.1",
-        "victory-pie": "^36.2.1",
-        "victory-scatter": "^36.2.1",
-        "victory-stack": "^36.2.1",
-        "victory-tooltip": "^36.2.1",
-        "victory-voronoi-container": "^36.2.1",
-        "victory-zoom-container": "^36.2.1"
+        "victory-area": "^36.6.7",
+        "victory-axis": "^36.6.7",
+        "victory-bar": "^36.6.7",
+        "victory-chart": "^36.6.7",
+        "victory-core": "^36.6.7",
+        "victory-create-container": "^36.6.7",
+        "victory-cursor-container": "^36.6.7",
+        "victory-group": "^36.6.7",
+        "victory-legend": "^36.6.7",
+        "victory-line": "^36.6.7",
+        "victory-pie": "^36.6.7",
+        "victory-scatter": "^36.6.7",
+        "victory-stack": "^36.6.7",
+        "victory-tooltip": "^36.6.7",
+        "victory-voronoi-container": "^36.6.7",
+        "victory-zoom-container": "^36.6.7"
       },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@patternfly/react-core": {
-      "version": "4.239.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.239.0.tgz",
-      "integrity": "sha512-6CmYABCJLUXTlzCk6C3WouMNZpS0BCT+aHU8CvYpFQ/NrpYp3MJaDsYbqgCRWV42rmIO5iXun/4WhXBJzJEoQg==",
-      "dependencies": {
-        "@patternfly/react-icons": "^4.90.0",
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "focus-trap": "6.9.2",
-        "react-dropzone": "9.0.0",
-        "tippy.js": "5.1.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@patternfly/react-icons": {
-      "version": "4.93.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-      "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-core": {
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.12.tgz",
+      "integrity": "sha512-RI1xS1JGJdE/FvpkMzawaE21oeTc/e+WbxvFXqZfLhTz60P8RzVG1nYWXDL747Onkz3SYtY79PhQ8nsLeO5sJQ==",
+      "dependencies": {
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "focus-trap": "7.6.2",
+        "react-dropzone": "^14.2.3",
+        "tslib": "^2.7.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
+      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
+    },
+    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-tokens": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
+      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
+    },
+    "node_modules/@patternfly/react-icons": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
+      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
@@ -3371,39 +3380,31 @@
       "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.108.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.108.0.tgz",
-      "integrity": "sha512-EUvd3rlkE1UXobAm7L6JHgNE3TW8IYTaVwwH/px4Mkn5mBayDO6f+w6QM3OeoDQVZcXK6IYFe7QQaYd/vWIJCQ==",
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.13.tgz",
+      "integrity": "sha512-cYw+pgpZXKGg3dZxudteUURqmj5O0ec7aNE80NLqFTcnI0MAOnfrFzCNApXJErn+MjD0VolMcC+H48eaRkT8TA==",
       "dependencies": {
-        "@patternfly/react-core": "^4.239.0",
-        "@patternfly/react-icons": "^4.90.0",
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0"
+        "@patternfly/react-core": "^5.4.12",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.7.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
-      "version": "4.278.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.278.0.tgz",
-      "integrity": "sha512-w+0WgSa5O64yi50PpkYuuIt5N5S9svkJKxrhV4LQzOhAtSRTtbraOBRwEKodppT/oUeKMlAdDUWep1O3QluF3Q==",
-      "dependencies": {
-        "@patternfly/react-icons": "^4.93.7",
-        "@patternfly/react-styles": "^4.92.8",
-        "@patternfly/react-tokens": "^4.94.7",
-        "focus-trap": "6.9.2",
-        "react-dropzone": "9.0.0",
-        "tippy.js": "5.1.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
+      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
+    },
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-tokens": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
+      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
     },
     "node_modules/@patternfly/react-tokens": {
       "version": "4.94.7",
@@ -3560,58 +3561,58 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.8.tgz",
-      "integrity": "sha512-2xAVyAUgaXHX9fubjcCbGAUOqYfRJN1em1EKR2HfzWBpObZhwfnZKvofTN4TplMqJdFQao61I+NVSai/vnBvDQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
     },
     "node_modules/@types/d3-color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.1.tgz",
-      "integrity": "sha512-CSAVrHAtM9wfuLJ2tpvvwCU/F22sm7rMHNN+yh9D6O6hyAms3+O0cgMpC1pm6UEUMOntuZC8bMt74PteiDUdCg=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "node_modules/@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "node_modules/@types/d3-interpolate": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.2.tgz",
-      "integrity": "sha512-zAbCj9lTqW9J9PlF4FwnvEjXZUy75NQqPm7DMHZXuxCFTpuTrdK2NMYGQekf4hlasL78fCYOLu4EE3/tXElwow==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "dependencies": {
         "@types/d3-color": "*"
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.5.tgz",
-      "integrity": "sha512-w/C++3W394MHzcLKO2kdsIn5KKNTOqeQVzyPSGPLzQbkPw/jpeaGtSRlakcKevGgGsjJxGsbqS0fPrVFDbHrDA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
       "dependencies": {
         "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.3.tgz",
-      "integrity": "sha512-cHMdIq+rhF5IVwAV7t61pcEXfEHsEsrbBUPkFGBwTXuxtTAkBBrnrNA8++6OWm3jwVsXoZYQM8NEekg6CPJ3zw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.1.tgz",
-      "integrity": "sha512-5j/AnefKAhCw4HpITmLDTPlf4vhi8o/dES+zbegfPb7LaGfNyqkLxBR6E+4yvTAgnJLmhe80EXFMzUs38fw4oA=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
     "node_modules/@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -4791,13 +4792,9 @@
       }
     },
     "node_modules/attr-accept": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
-      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.5.0"
-      },
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
       "engines": {
         "node": ">=4"
       }
@@ -6534,13 +6531,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "hasInstallScript": true,
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.25.1",
@@ -8490,15 +8480,14 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
-      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "dependencies": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.7.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -8609,11 +8598,11 @@
       "license": "ISC"
     },
     "node_modules/focus-trap": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
-      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "dependencies": {
-        "tabbable": "^5.3.2"
+        "tabbable": "^6.2.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -12582,16 +12571,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -12856,19 +12835,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -13082,21 +13048,19 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
-      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
-      "license": "MIT",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
       "dependencies": {
-        "attr-accept": "^1.1.3",
-        "file-selector": "^0.1.8",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0"
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10.13"
       },
       "peerDependencies": {
-        "react": ">=0.14.0"
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-fast-compare": {
@@ -14704,9 +14668,9 @@
       "dev": true
     },
     "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -14896,15 +14860,6 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tippy.js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
-      "integrity": "sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==",
-      "license": "MIT",
-      "dependencies": {
-        "popper.js": "^1.16.0"
-      }
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -15153,9 +15108,9 @@
       "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -15574,263 +15529,246 @@
       }
     },
     "node_modules/victory-area": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.11.tgz",
-      "integrity": "sha512-M/wQ0ryms6WpqGzpv+BMNfCLy0dlOtIxAuYgXJYwwDu55noAMbWlFahIzfllpjTmFOyCpCXF7EDraC3n2xRRFQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.9.2.tgz",
+      "integrity": "sha512-32aharvPf2RgdQB+/u1j3/ajYFNH/7ugLX9ZRpdd65gP6QEbtXL+58gS6CxvFw6gr/y8a0xMlkMKkpDVacXLpw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-axis": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.11.tgz",
-      "integrity": "sha512-f2PUbEsE5wYXKRrgSYdoPRV6QXKNrZjTcd8YlymVGWsouJEFRZFOig8N3yU5lM7OuP98tOdurk4I91Py6NlXrA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.9.2.tgz",
+      "integrity": "sha512-4Odws+IAjprJtBg2b2ZCxEPgrQ6LgIOa22cFkGghzOSfTyNayN4M3AauNB44RZyn2O/hDiM1gdBkEg1g9YDevQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-bar": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.11.tgz",
-      "integrity": "sha512-ANXZIYiDcvC1k3fvGbE8qHOi0POGOsYbzTgP/SBHXh9VQYa/NaYGZT3RO1mxp8wgpwaF+NZYZNC8mMO1pvcB2w==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.9.2.tgz",
+      "integrity": "sha512-R3LFoR91FzwWcnyGK2P8DHNVv9gsaWhl5pSr2KdeNtvLbZVEIvUkTeVN9RMBMzterSFPw0mbWhS1Asb3sV6PPw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-brush-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.11.tgz",
-      "integrity": "sha512-o0pPKzfQhKRlYNYUx3tHjuv9iTXqvgRtmu59L/h6l11DPaRo+jcHDBKEDRuoZxTinR/a1yqfLEJ1i9QgSE8o6w==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.9.2.tgz",
+      "integrity": "sha512-KcQjzFeo40tn52cJf1A02l5MqeR9GKkk3loDqM3T2hfi1PCyUrZXEUjGN5HNlLizDRvtcemaAHNAWlb70HbG/g==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-chart": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.11.tgz",
-      "integrity": "sha512-t4RIeLT6PJxZaDqNeawtIPxuA48k98kBvYbEV9XEPrS3TPAYsrB6lgXjZKLoItYLh63Ry4nqZAnPti4RD0uTfQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.9.2.tgz",
+      "integrity": "sha512-dMNcS0BpqL3YiGvI4BSEmPR76FCksCgf3K4CSZ7C/MGyrElqB6wWwzk7afnlB1Qr71YIHXDmdwsPNAl/iEwTtA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.11",
-        "victory-core": "^36.6.11",
-        "victory-polar-axis": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-axis": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-polar-axis": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-core": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.11.tgz",
-      "integrity": "sha512-aYhFIRu8NQMwW/JbgqoAG7w0lUYbTB1Achx4mmBc6aL8RMkv6LhD/PFwjT3TLpH0AoEs3Rpty2g0UQ+7ulE7dA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.9.2.tgz",
+      "integrity": "sha512-AzmMy+9MYMaaRmmZZovc/Po9urHne3R3oX7bbXeQdVuK/uMBrlPiv11gVJnuEH2SXLVyep43jlKgaBp8ef9stQ==",
       "dependencies": {
         "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.11"
+        "victory-vendor": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-create-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.11.tgz",
-      "integrity": "sha512-Ve96DE9XDifmT2Bh/6Ptz7cgIV5DC2GYsr0Rl6I0sF6S02IH3V02NLpkcTthTRJHAvC9MkHwjiBlvFEZsXHOtg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.9.2.tgz",
+      "integrity": "sha512-uA0dh1R0YDzuXyE/7StZvq4qshet+WYceY7R1UR5mR/F9079xy+iQsa2Ca4h97/GtVZoLO6r1eKLWBt9TN+U7A==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.11",
-        "victory-core": "^36.6.11",
-        "victory-cursor-container": "^36.6.11",
-        "victory-selection-container": "^36.6.11",
-        "victory-voronoi-container": "^36.6.11",
-        "victory-zoom-container": "^36.6.11"
+        "victory-brush-container": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-cursor-container": "^36.9.2",
+        "victory-selection-container": "^36.9.2",
+        "victory-voronoi-container": "^36.9.2",
+        "victory-zoom-container": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-cursor-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.11.tgz",
-      "integrity": "sha512-rdQAZb3RGYfijjqIQkuPGLNY5UOhuqyzlxQFaVtkpkDSZKiPMtbfLvR7F0Yfa9cs8OeQU0KAtAiK8R33o7su/Q==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.9.2.tgz",
+      "integrity": "sha512-jidab4j3MaciF3fGX70jTj4H9rrLcY8o2LUrhJ67ZLvEFGGmnPtph+p8Fe97Umrag7E/DszjNxQZolpwlgUh3g==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-group": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.11.tgz",
-      "integrity": "sha512-PTRrH31gsGk3KFzeTzAkyvgjtilWYHWkx06oouh70KuAJ7f+9pRMrRMal8v+npH6a8Wp0KKW198AqpkPaZqHyQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.9.2.tgz",
+      "integrity": "sha512-wBmpsjBTKva8mxHvHNY3b8RE58KtnpLLItEyyAHaYkmExwt3Uj8Cld3sF3vmeuijn2iR64NPKeMbgMbfZJzycw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-legend": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.11.tgz",
-      "integrity": "sha512-eL310Qh3WcZyjFI18hABVodwHpgZtokHD3r5HKpgZVY8MWkMD9mXErphWbkNHTVi5ya+I3QbRQ7ToRbPUl/Jog==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.9.2.tgz",
+      "integrity": "sha512-cucFJpv6fty+yXp5pElQFQnHBk1TqA4guGUMI+XF/wLlnuM4bhdAtASobRIIBkz0mHGBaCAAV4PzL9azPU/9dg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-line": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.11.tgz",
-      "integrity": "sha512-SDQCS6qDSixnYPB1kHEQsue06N6x2cxkIA6uqL45LRFMkKWG4OtwTBORVhtK6lfKzq1OvJs3msoZ+uoRIW1gaA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.9.2.tgz",
+      "integrity": "sha512-kmYFZUo0o2xC8cXRsmt/oUBRQSZJVT2IJnAkboUepypoj09e6CY5tRH4TSdfEDGkBk23xQkn7d4IFgl4kAGnSA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-pie": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.11.tgz",
-      "integrity": "sha512-vQPAzrubo3BX/1pujSlKKTBGNSj/8fxUJ0vSZPZ6EE1y6SRnPJoLYi2OkDQVT1s3rM9xvW00SflCD3GO/Z3xWA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.9.2.tgz",
+      "integrity": "sha512-i3zWezvy5wQEkhXKt4rS9ILGH7Vr9Q5eF9fKO4GMwDPBdYOTE3Dh2tVaSrfDC8g9zFIc0DKzOtVoJRTb+0AkPg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-polar-axis": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.11.tgz",
-      "integrity": "sha512-wDkyY1rKQTRUVt4+e0QNQgSIJCqXazNhkjWXla8ZWj52GzPP/QSDuzr8SO1oHA3++1jOpdD0R2FTxm+pAea/Yw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.9.2.tgz",
+      "integrity": "sha512-HBR90FF4M56yf/atXjSmy3DMps1vSAaLXmdVXLM/A5g+0pUS7HO719r5x6dsR3I6Rm+8x6Kk8xJs0qgpnGQIEw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-scatter": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.11.tgz",
-      "integrity": "sha512-x46AfmhiKijXe59kqm7xI0CCjbY8J0VB02HUN3TynMx7xzhW2yOP+QQqgyk+C4im/MS33HKU402Q7cUfF3pgtw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.9.2.tgz",
+      "integrity": "sha512-hK9AtbJQfaW05i8BH7Lf1HK7vWMAfQofj23039HEQJqTKbCL77YT+Q0LhZw1a1BRCpC/5aSg9EuqblhfIYw2wg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-selection-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.11.tgz",
-      "integrity": "sha512-pRQz++0ERZVuIgxpmqLkDgf6hiCAS2m8iGcox8tryWzE1NpADG/IJiHh3AeJgGeiLNMeoJ48hsOZP1C9CCxwrQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.9.2.tgz",
+      "integrity": "sha512-chboroEwqqVlMB60kveXM2WznJ33ZM00PWkFVCoJDzHHlYs7TCADxzhqet2S67SbZGSyvSprY2YztSxX8kZ+XQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-shared-events": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.11.tgz",
-      "integrity": "sha512-ia6ijfgfYMb+gGFPEq4F6rqzB9p5EkjKpjvmEv4Ww7VjrtdORu7PPfAgTxXw/9QgFSq4iOUnDtzjObABua09fQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.9.2.tgz",
+      "integrity": "sha512-W/atiw3Or6MnpBuhluFv6007YrixIRh5NtiRvtFLGxNuQJLYjaSh6koRAih5xJer5Pj7YUx0tL9x67jTRcJ6Dg==",
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-stack": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.11.tgz",
-      "integrity": "sha512-kE/915RdcKes69WpxZ5j6MyCIJqdzIZnzIg6OArBeDlD+LuinNb2oNxYpMXzur1KFSyk5PCUckHgEbR2XLoXrw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.9.2.tgz",
+      "integrity": "sha512-imR6FniVlDFlBa/B3Est8kTryNhWj2ZNpivmVOebVDxkKcVlLaDg3LotCUOI7NzOhBQaro0UzeE9KmZV93JcYA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-tooltip": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.11.tgz",
-      "integrity": "sha512-YxAPkGAqTYOIW4aE5InGFABmYjiBfuQFjCe9hwFGvIC/Uqn202xgs5kYVEZXUX3vc9W8XOl7plaQJzmtr2ZZBQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.9.2.tgz",
+      "integrity": "sha512-76seo4TWD1WfZHJQH87IP3tlawv38DuwrUxpnTn8+uW6/CUex82poQiVevYdmJzhataS9jjyCWv3w7pOmLBCLg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.11.tgz",
-      "integrity": "sha512-nT8kCiJp8dQh8g991J/R5w5eE2KnO8EAIP0xocWlh9l2okngMWglOPoMZzJvek8Q1KUc4XE/mJxTZnvOB1sTYg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
       "dependencies": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -15849,29 +15787,27 @@
       }
     },
     "node_modules/victory-voronoi-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.11.tgz",
-      "integrity": "sha512-KNB814e5uhs00oNFdkPucXMlpNILnWabHM7iKLBz26nlgqiu6dctZZoWU+HKjxbPkHdic6JQsg28Nk5bThaulw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.9.2.tgz",
+      "integrity": "sha512-NIVYqck9N4OQnEz9mgQ4wILsci3OBWWK7RLuITGHyoD7Ne/+WH1i0Pv2y9eIx+f55rc928FUTugPPhkHvXyH3A==",
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-tooltip": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-tooltip": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-zoom-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.11.tgz",
-      "integrity": "sha512-DRS12HZEmy5oJanlnSK9Wtp/6HQQbwvK0idVU+Lhf2lw3r9gauWp/ymWwWzaHd7Mn5cCODuNW1le2bqb71j3wg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.9.2.tgz",
+      "integrity": "sha512-pXa2Ji6EX/pIarKT6Hcmmu2n7IG/x8Vs0D2eACQ/nbpvZa+DXWIxCRW4hcg2Va35fmXcDIEpGaX3/soXzZ+pbw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
@@ -15998,15 +15934,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -18966,56 +18893,67 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "4.215.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.215.1.tgz",
-      "integrity": "sha512-coOipHiQs92OYYO+pWfukEKOkY+VUL6ptusTxh98DvIu/tQYzJDJxEmzYXmwqxORM19oLxAJEGktPoLNKElj6A=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
+      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA=="
     },
     "@patternfly/react-charts": {
-      "version": "6.92.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.92.0.tgz",
-      "integrity": "sha512-aQl+L7zH/tWX00L2xI6B0414xweaIocR98wbyhXLi6zknkhcAUcE2zITFIW4+EsU+qPvUlptwRiRufoH8/BlEw==",
+      "version": "6.94.21",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.21.tgz",
+      "integrity": "sha512-/okakDxebgSacl9gnIifMjqLMGwuwqXogEIDX+TFveIGx9BBhXg+RLnSpSZS8xQMjEcSVppdz320IN2o+YgpaQ==",
       "requires": {
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
+        "@patternfly/react-styles": "^4.92.8",
+        "@patternfly/react-tokens": "^4.94.7",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0",
-        "victory-area": "^36.2.1",
-        "victory-axis": "^36.2.1",
-        "victory-bar": "^36.2.1",
-        "victory-chart": "^36.2.1",
-        "victory-core": "^36.2.1",
-        "victory-create-container": "^36.2.1",
-        "victory-cursor-container": "^36.2.1",
-        "victory-group": "^36.2.1",
-        "victory-legend": "^36.2.1",
-        "victory-line": "^36.2.1",
-        "victory-pie": "^36.2.1",
-        "victory-scatter": "^36.2.1",
-        "victory-stack": "^36.2.1",
-        "victory-tooltip": "^36.2.1",
-        "victory-voronoi-container": "^36.2.1",
-        "victory-zoom-container": "^36.2.1"
+        "victory-area": "^36.6.7",
+        "victory-axis": "^36.6.7",
+        "victory-bar": "^36.6.7",
+        "victory-chart": "^36.6.7",
+        "victory-core": "^36.6.7",
+        "victory-create-container": "^36.6.7",
+        "victory-cursor-container": "^36.6.7",
+        "victory-group": "^36.6.7",
+        "victory-legend": "^36.6.7",
+        "victory-line": "^36.6.7",
+        "victory-pie": "^36.6.7",
+        "victory-scatter": "^36.6.7",
+        "victory-stack": "^36.6.7",
+        "victory-tooltip": "^36.6.7",
+        "victory-voronoi-container": "^36.6.7",
+        "victory-zoom-container": "^36.6.7"
       }
     },
     "@patternfly/react-core": {
-      "version": "4.239.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.239.0.tgz",
-      "integrity": "sha512-6CmYABCJLUXTlzCk6C3WouMNZpS0BCT+aHU8CvYpFQ/NrpYp3MJaDsYbqgCRWV42rmIO5iXun/4WhXBJzJEoQg==",
+      "version": "5.4.12",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.12.tgz",
+      "integrity": "sha512-RI1xS1JGJdE/FvpkMzawaE21oeTc/e+WbxvFXqZfLhTz60P8RzVG1nYWXDL747Onkz3SYtY79PhQ8nsLeO5sJQ==",
       "requires": {
-        "@patternfly/react-icons": "^4.90.0",
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "focus-trap": "6.9.2",
-        "react-dropzone": "9.0.0",
-        "tippy.js": "5.1.2",
-        "tslib": "^2.0.0"
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "focus-trap": "7.6.2",
+        "react-dropzone": "^14.2.3",
+        "tslib": "^2.7.0"
+      },
+      "dependencies": {
+        "@patternfly/react-styles": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
+          "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
+          "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
+        }
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.93.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-      "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
+      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
       "requires": {}
     },
     "@patternfly/react-styles": {
@@ -19024,31 +18962,27 @@
       "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
     },
     "@patternfly/react-table": {
-      "version": "4.108.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.108.0.tgz",
-      "integrity": "sha512-EUvd3rlkE1UXobAm7L6JHgNE3TW8IYTaVwwH/px4Mkn5mBayDO6f+w6QM3OeoDQVZcXK6IYFe7QQaYd/vWIJCQ==",
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.13.tgz",
+      "integrity": "sha512-cYw+pgpZXKGg3dZxudteUURqmj5O0ec7aNE80NLqFTcnI0MAOnfrFzCNApXJErn+MjD0VolMcC+H48eaRkT8TA==",
       "requires": {
-        "@patternfly/react-core": "^4.239.0",
-        "@patternfly/react-icons": "^4.90.0",
-        "@patternfly/react-styles": "^4.89.0",
-        "@patternfly/react-tokens": "^4.91.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0"
+        "@patternfly/react-core": "^5.4.12",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.7.0"
       },
       "dependencies": {
-        "@patternfly/react-core": {
-          "version": "4.278.0",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.278.0.tgz",
-          "integrity": "sha512-w+0WgSa5O64yi50PpkYuuIt5N5S9svkJKxrhV4LQzOhAtSRTtbraOBRwEKodppT/oUeKMlAdDUWep1O3QluF3Q==",
-          "requires": {
-            "@patternfly/react-icons": "^4.93.7",
-            "@patternfly/react-styles": "^4.92.8",
-            "@patternfly/react-tokens": "^4.94.7",
-            "focus-trap": "6.9.2",
-            "react-dropzone": "9.0.0",
-            "tippy.js": "5.1.2",
-            "tslib": "^2.0.0"
-          }
+        "@patternfly/react-styles": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
+          "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
+          "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
         }
       }
     },
@@ -19191,58 +19125,58 @@
       }
     },
     "@types/d3-array": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.8.tgz",
-      "integrity": "sha512-2xAVyAUgaXHX9fubjcCbGAUOqYfRJN1em1EKR2HfzWBpObZhwfnZKvofTN4TplMqJdFQao61I+NVSai/vnBvDQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
     },
     "@types/d3-color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.1.tgz",
-      "integrity": "sha512-CSAVrHAtM9wfuLJ2tpvvwCU/F22sm7rMHNN+yh9D6O6hyAms3+O0cgMpC1pm6UEUMOntuZC8bMt74PteiDUdCg=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "@types/d3-ease": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
-      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "@types/d3-interpolate": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.2.tgz",
-      "integrity": "sha512-zAbCj9lTqW9J9PlF4FwnvEjXZUy75NQqPm7DMHZXuxCFTpuTrdK2NMYGQekf4hlasL78fCYOLu4EE3/tXElwow==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "requires": {
         "@types/d3-color": "*"
       }
     },
     "@types/d3-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
-      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
     },
     "@types/d3-scale": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.5.tgz",
-      "integrity": "sha512-w/C++3W394MHzcLKO2kdsIn5KKNTOqeQVzyPSGPLzQbkPw/jpeaGtSRlakcKevGgGsjJxGsbqS0fPrVFDbHrDA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
       "requires": {
         "@types/d3-time": "*"
       }
     },
     "@types/d3-shape": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.3.tgz",
-      "integrity": "sha512-cHMdIq+rhF5IVwAV7t61pcEXfEHsEsrbBUPkFGBwTXuxtTAkBBrnrNA8++6OWm3jwVsXoZYQM8NEekg6CPJ3zw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "requires": {
         "@types/d3-path": "*"
       }
     },
     "@types/d3-time": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.1.tgz",
-      "integrity": "sha512-5j/AnefKAhCw4HpITmLDTPlf4vhi8o/dES+zbegfPb7LaGfNyqkLxBR6E+4yvTAgnJLmhe80EXFMzUs38fw4oA=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
     "@types/d3-timer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
-      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "@types/estree": {
       "version": "1.0.6",
@@ -20148,12 +20082,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.3.tgz",
-      "integrity": "sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==",
-      "requires": {
-        "core-js": "^2.5.0"
-      }
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -21389,11 +21320,6 @@
           "dev": true
         }
       }
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-js-compat": {
       "version": "3.25.1",
@@ -22796,11 +22722,11 @@
       }
     },
     "file-selector": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.19.tgz",
-      "integrity": "sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "requires": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.7.0"
       }
     },
     "fill-range": {
@@ -22888,11 +22814,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
-      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "requires": {
-        "tabbable": "^5.3.2"
+        "tabbable": "^6.2.0"
       }
     },
     "follow-redirects": {
@@ -25684,11 +25610,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -25854,15 +25775,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
       }
     },
     "proxy-addr": {
@@ -26032,14 +25944,13 @@
       }
     },
     "react-dropzone": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-9.0.0.tgz",
-      "integrity": "sha512-wZ2o9B2qkdE3RumWhfyZT9swgJYJPeU5qHEcMU8weYpmLex1eeWX0CC32/Y0VutB+BBi2D+iePV/YZIiB4kZGw==",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
       "requires": {
-        "attr-accept": "^1.1.3",
-        "file-selector": "^0.1.8",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0"
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
       }
     },
     "react-fast-compare": {
@@ -27246,9 +27157,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tapable": {
       "version": "2.2.1",
@@ -27383,14 +27294,6 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "dev": true
-    },
-    "tippy.js": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.1.2.tgz",
-      "integrity": "sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==",
-      "requires": {
-        "popper.js": "^1.16.0"
-      }
     },
     "tmp": {
       "version": "0.2.1",
@@ -27549,9 +27452,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -27849,209 +27752,192 @@
       }
     },
     "victory-area": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.11.tgz",
-      "integrity": "sha512-M/wQ0ryms6WpqGzpv+BMNfCLy0dlOtIxAuYgXJYwwDu55noAMbWlFahIzfllpjTmFOyCpCXF7EDraC3n2xRRFQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.9.2.tgz",
+      "integrity": "sha512-32aharvPf2RgdQB+/u1j3/ajYFNH/7ugLX9ZRpdd65gP6QEbtXL+58gS6CxvFw6gr/y8a0xMlkMKkpDVacXLpw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       }
     },
     "victory-axis": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.11.tgz",
-      "integrity": "sha512-f2PUbEsE5wYXKRrgSYdoPRV6QXKNrZjTcd8YlymVGWsouJEFRZFOig8N3yU5lM7OuP98tOdurk4I91Py6NlXrA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.9.2.tgz",
+      "integrity": "sha512-4Odws+IAjprJtBg2b2ZCxEPgrQ6LgIOa22cFkGghzOSfTyNayN4M3AauNB44RZyn2O/hDiM1gdBkEg1g9YDevQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-bar": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.11.tgz",
-      "integrity": "sha512-ANXZIYiDcvC1k3fvGbE8qHOi0POGOsYbzTgP/SBHXh9VQYa/NaYGZT3RO1mxp8wgpwaF+NZYZNC8mMO1pvcB2w==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.9.2.tgz",
+      "integrity": "sha512-R3LFoR91FzwWcnyGK2P8DHNVv9gsaWhl5pSr2KdeNtvLbZVEIvUkTeVN9RMBMzterSFPw0mbWhS1Asb3sV6PPw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       }
     },
     "victory-brush-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.11.tgz",
-      "integrity": "sha512-o0pPKzfQhKRlYNYUx3tHjuv9iTXqvgRtmu59L/h6l11DPaRo+jcHDBKEDRuoZxTinR/a1yqfLEJ1i9QgSE8o6w==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.9.2.tgz",
+      "integrity": "sha512-KcQjzFeo40tn52cJf1A02l5MqeR9GKkk3loDqM3T2hfi1PCyUrZXEUjGN5HNlLizDRvtcemaAHNAWlb70HbG/g==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-chart": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.11.tgz",
-      "integrity": "sha512-t4RIeLT6PJxZaDqNeawtIPxuA48k98kBvYbEV9XEPrS3TPAYsrB6lgXjZKLoItYLh63Ry4nqZAnPti4RD0uTfQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.9.2.tgz",
+      "integrity": "sha512-dMNcS0BpqL3YiGvI4BSEmPR76FCksCgf3K4CSZ7C/MGyrElqB6wWwzk7afnlB1Qr71YIHXDmdwsPNAl/iEwTtA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.11",
-        "victory-core": "^36.6.11",
-        "victory-polar-axis": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-axis": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-polar-axis": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       }
     },
     "victory-core": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.11.tgz",
-      "integrity": "sha512-aYhFIRu8NQMwW/JbgqoAG7w0lUYbTB1Achx4mmBc6aL8RMkv6LhD/PFwjT3TLpH0AoEs3Rpty2g0UQ+7ulE7dA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.9.2.tgz",
+      "integrity": "sha512-AzmMy+9MYMaaRmmZZovc/Po9urHne3R3oX7bbXeQdVuK/uMBrlPiv11gVJnuEH2SXLVyep43jlKgaBp8ef9stQ==",
       "requires": {
         "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.11"
+        "victory-vendor": "^36.9.2"
       }
     },
     "victory-create-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.11.tgz",
-      "integrity": "sha512-Ve96DE9XDifmT2Bh/6Ptz7cgIV5DC2GYsr0Rl6I0sF6S02IH3V02NLpkcTthTRJHAvC9MkHwjiBlvFEZsXHOtg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.9.2.tgz",
+      "integrity": "sha512-uA0dh1R0YDzuXyE/7StZvq4qshet+WYceY7R1UR5mR/F9079xy+iQsa2Ca4h97/GtVZoLO6r1eKLWBt9TN+U7A==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.11",
-        "victory-core": "^36.6.11",
-        "victory-cursor-container": "^36.6.11",
-        "victory-selection-container": "^36.6.11",
-        "victory-voronoi-container": "^36.6.11",
-        "victory-zoom-container": "^36.6.11"
+        "victory-brush-container": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-cursor-container": "^36.9.2",
+        "victory-selection-container": "^36.9.2",
+        "victory-voronoi-container": "^36.9.2",
+        "victory-zoom-container": "^36.9.2"
       }
     },
     "victory-cursor-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.11.tgz",
-      "integrity": "sha512-rdQAZb3RGYfijjqIQkuPGLNY5UOhuqyzlxQFaVtkpkDSZKiPMtbfLvR7F0Yfa9cs8OeQU0KAtAiK8R33o7su/Q==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.9.2.tgz",
+      "integrity": "sha512-jidab4j3MaciF3fGX70jTj4H9rrLcY8o2LUrhJ67ZLvEFGGmnPtph+p8Fe97Umrag7E/DszjNxQZolpwlgUh3g==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-group": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.11.tgz",
-      "integrity": "sha512-PTRrH31gsGk3KFzeTzAkyvgjtilWYHWkx06oouh70KuAJ7f+9pRMrRMal8v+npH6a8Wp0KKW198AqpkPaZqHyQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.9.2.tgz",
+      "integrity": "sha512-wBmpsjBTKva8mxHvHNY3b8RE58KtnpLLItEyyAHaYkmExwt3Uj8Cld3sF3vmeuijn2iR64NPKeMbgMbfZJzycw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       }
     },
     "victory-legend": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.11.tgz",
-      "integrity": "sha512-eL310Qh3WcZyjFI18hABVodwHpgZtokHD3r5HKpgZVY8MWkMD9mXErphWbkNHTVi5ya+I3QbRQ7ToRbPUl/Jog==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.9.2.tgz",
+      "integrity": "sha512-cucFJpv6fty+yXp5pElQFQnHBk1TqA4guGUMI+XF/wLlnuM4bhdAtASobRIIBkz0mHGBaCAAV4PzL9azPU/9dg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-line": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.11.tgz",
-      "integrity": "sha512-SDQCS6qDSixnYPB1kHEQsue06N6x2cxkIA6uqL45LRFMkKWG4OtwTBORVhtK6lfKzq1OvJs3msoZ+uoRIW1gaA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.9.2.tgz",
+      "integrity": "sha512-kmYFZUo0o2xC8cXRsmt/oUBRQSZJVT2IJnAkboUepypoj09e6CY5tRH4TSdfEDGkBk23xQkn7d4IFgl4kAGnSA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       }
     },
     "victory-pie": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.11.tgz",
-      "integrity": "sha512-vQPAzrubo3BX/1pujSlKKTBGNSj/8fxUJ0vSZPZ6EE1y6SRnPJoLYi2OkDQVT1s3rM9xvW00SflCD3GO/Z3xWA==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.9.2.tgz",
+      "integrity": "sha512-i3zWezvy5wQEkhXKt4rS9ILGH7Vr9Q5eF9fKO4GMwDPBdYOTE3Dh2tVaSrfDC8g9zFIc0DKzOtVoJRTb+0AkPg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11",
-        "victory-vendor": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
       }
     },
     "victory-polar-axis": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.11.tgz",
-      "integrity": "sha512-wDkyY1rKQTRUVt4+e0QNQgSIJCqXazNhkjWXla8ZWj52GzPP/QSDuzr8SO1oHA3++1jOpdD0R2FTxm+pAea/Yw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.9.2.tgz",
+      "integrity": "sha512-HBR90FF4M56yf/atXjSmy3DMps1vSAaLXmdVXLM/A5g+0pUS7HO719r5x6dsR3I6Rm+8x6Kk8xJs0qgpnGQIEw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-scatter": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.11.tgz",
-      "integrity": "sha512-x46AfmhiKijXe59kqm7xI0CCjbY8J0VB02HUN3TynMx7xzhW2yOP+QQqgyk+C4im/MS33HKU402Q7cUfF3pgtw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.9.2.tgz",
+      "integrity": "sha512-hK9AtbJQfaW05i8BH7Lf1HK7vWMAfQofj23039HEQJqTKbCL77YT+Q0LhZw1a1BRCpC/5aSg9EuqblhfIYw2wg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-selection-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.11.tgz",
-      "integrity": "sha512-pRQz++0ERZVuIgxpmqLkDgf6hiCAS2m8iGcox8tryWzE1NpADG/IJiHh3AeJgGeiLNMeoJ48hsOZP1C9CCxwrQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.9.2.tgz",
+      "integrity": "sha512-chboroEwqqVlMB60kveXM2WznJ33ZM00PWkFVCoJDzHHlYs7TCADxzhqet2S67SbZGSyvSprY2YztSxX8kZ+XQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-shared-events": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.11.tgz",
-      "integrity": "sha512-ia6ijfgfYMb+gGFPEq4F6rqzB9p5EkjKpjvmEv4Ww7VjrtdORu7PPfAgTxXw/9QgFSq4iOUnDtzjObABua09fQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.9.2.tgz",
+      "integrity": "sha512-W/atiw3Or6MnpBuhluFv6007YrixIRh5NtiRvtFLGxNuQJLYjaSh6koRAih5xJer5Pj7YUx0tL9x67jTRcJ6Dg==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-stack": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.11.tgz",
-      "integrity": "sha512-kE/915RdcKes69WpxZ5j6MyCIJqdzIZnzIg6OArBeDlD+LuinNb2oNxYpMXzur1KFSyk5PCUckHgEbR2XLoXrw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.9.2.tgz",
+      "integrity": "sha512-imR6FniVlDFlBa/B3Est8kTryNhWj2ZNpivmVOebVDxkKcVlLaDg3LotCUOI7NzOhBQaro0UzeE9KmZV93JcYA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-shared-events": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
       }
     },
     "victory-tooltip": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.11.tgz",
-      "integrity": "sha512-YxAPkGAqTYOIW4aE5InGFABmYjiBfuQFjCe9hwFGvIC/Uqn202xgs5kYVEZXUX3vc9W8XOl7plaQJzmtr2ZZBQ==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.9.2.tgz",
+      "integrity": "sha512-76seo4TWD1WfZHJQH87IP3tlawv38DuwrUxpnTn8+uW6/CUex82poQiVevYdmJzhataS9jjyCWv3w7pOmLBCLg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "victory-vendor": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.11.tgz",
-      "integrity": "sha512-nT8kCiJp8dQh8g991J/R5w5eE2KnO8EAIP0xocWlh9l2okngMWglOPoMZzJvek8Q1KUc4XE/mJxTZnvOB1sTYg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
       "requires": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -28070,26 +27956,24 @@
       }
     },
     "victory-voronoi-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.11.tgz",
-      "integrity": "sha512-KNB814e5uhs00oNFdkPucXMlpNILnWabHM7iKLBz26nlgqiu6dctZZoWU+HKjxbPkHdic6JQsg28Nk5bThaulw==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.9.2.tgz",
+      "integrity": "sha512-NIVYqck9N4OQnEz9mgQ4wILsci3OBWWK7RLuITGHyoD7Ne/+WH1i0Pv2y9eIx+f55rc928FUTugPPhkHvXyH3A==",
       "requires": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.11",
-        "victory-tooltip": "^36.6.11"
+        "victory-core": "^36.9.2",
+        "victory-tooltip": "^36.9.2"
       }
     },
     "victory-zoom-container": {
-      "version": "36.6.11",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.11.tgz",
-      "integrity": "sha512-DRS12HZEmy5oJanlnSK9Wtp/6HQQbwvK0idVU+Lhf2lw3r9gauWp/ymWwWzaHd7Mn5cCODuNW1le2bqb71j3wg==",
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.9.2.tgz",
+      "integrity": "sha512-pXa2Ji6EX/pIarKT6Hcmmu2n7IG/x8Vs0D2eACQ/nbpvZa+DXWIxCRW4hcg2Va35fmXcDIEpGaX3/soXzZ+pbw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.11"
+        "victory-core": "^36.9.2"
       }
     },
     "vinyl": {
@@ -28194,14 +28078,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,13 +9,15 @@
       "version": "0.0.1",
       "dependencies": {
         "@grafana/lezer-logql": "^0.2.6",
-        "@patternfly/patternfly": "^5.4.2",
-        "@patternfly/react-charts": "^6.94.21",
-        "@patternfly/react-core": "^5.4.12",
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-table": "^5.4.13",
+        "@patternfly/patternfly": "^6.1.0",
+        "@patternfly/react-charts": "^8.1.0",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-table": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "i18next": "^22.4.12",
-        "react-i18next": "^11.18.6"
+        "react-i18next": "^11.18.6",
+        "victory": "^37.3.5"
       },
       "devDependencies": {
         "@cypress/code-coverage": "^3.10.0",
@@ -3302,114 +3304,148 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
-      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.1.0.tgz",
+      "integrity": "sha512-w+QazL8NHKkg5j01eotblsswKxQQSYB0CN3yBXQL9ScpHdp/fK8M6TqWbKZNRpf+NqhMxcH/om8eR0N/fDCJqw=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "6.94.21",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.21.tgz",
-      "integrity": "sha512-/okakDxebgSacl9gnIifMjqLMGwuwqXogEIDX+TFveIGx9BBhXg+RLnSpSZS8xQMjEcSVppdz320IN2o+YgpaQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.1.0.tgz",
+      "integrity": "sha512-nywK5d4WLCOyw3pcSlMHcGQezyHClwzsLEegO58QMh0GvsM2DvEsylpsJdQZIE3ApMd+RVu97XZD21EQKxpIiA==",
       "dependencies": {
-        "@patternfly/react-styles": "^4.92.8",
-        "@patternfly/react-tokens": "^4.94.7",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.6.7",
-        "victory-axis": "^36.6.7",
-        "victory-bar": "^36.6.7",
-        "victory-chart": "^36.6.7",
-        "victory-core": "^36.6.7",
-        "victory-create-container": "^36.6.7",
-        "victory-cursor-container": "^36.6.7",
-        "victory-group": "^36.6.7",
-        "victory-legend": "^36.6.7",
-        "victory-line": "^36.6.7",
-        "victory-pie": "^36.6.7",
-        "victory-scatter": "^36.6.7",
-        "victory-stack": "^36.6.7",
-        "victory-tooltip": "^36.6.7",
-        "victory-voronoi-container": "^36.6.7",
-        "victory-zoom-container": "^36.6.7"
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "lodash": "^4.17.21",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18",
+        "victory-area": "^37.3.3",
+        "victory-axis": "^37.3.2",
+        "victory-bar": "^37.3.2",
+        "victory-box-plot": "^37.3.2",
+        "victory-chart": "^37.3.3",
+        "victory-core": "^37.3.2",
+        "victory-create-container": "^37.3.2",
+        "victory-cursor-container": "^37.3.2",
+        "victory-group": "^37.3.2",
+        "victory-legend": "^37.3.2",
+        "victory-line": "^37.3.2",
+        "victory-pie": "^37.3.2",
+        "victory-scatter": "^37.3.2",
+        "victory-stack": "^37.3.2",
+        "victory-tooltip": "^37.3.2",
+        "victory-voronoi-container": "^37.3.2",
+        "victory-zoom-container": "^37.3.2"
+      },
+      "peerDependenciesMeta": {
+        "victory-area": {
+          "optional": true
+        },
+        "victory-axis": {
+          "optional": true
+        },
+        "victory-bar": {
+          "optional": true
+        },
+        "victory-box-plot": {
+          "optional": true
+        },
+        "victory-chart": {
+          "optional": true
+        },
+        "victory-core": {
+          "optional": true
+        },
+        "victory-create-container": {
+          "optional": true
+        },
+        "victory-cursor-container": {
+          "optional": true
+        },
+        "victory-group": {
+          "optional": true
+        },
+        "victory-legend": {
+          "optional": true
+        },
+        "victory-line": {
+          "optional": true
+        },
+        "victory-pie": {
+          "optional": true
+        },
+        "victory-scatter": {
+          "optional": true
+        },
+        "victory-stack": {
+          "optional": true
+        },
+        "victory-tooltip": {
+          "optional": true
+        },
+        "victory-voronoi-container": {
+          "optional": true
+        },
+        "victory-zoom-container": {
+          "optional": true
+        }
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.12.tgz",
-      "integrity": "sha512-RI1xS1JGJdE/FvpkMzawaE21oeTc/e+WbxvFXqZfLhTz60P8RzVG1nYWXDL747Onkz3SYtY79PhQ8nsLeO5sJQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0.tgz",
+      "integrity": "sha512-zj0lJPZxQanXKD8ae2kYnweT0kpp1CzpHYAkaBjTrw2k6ZMfr/UPlp0/ugCjWEokBqh79RUADLkKJJPce/yoSQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "focus-trap": "7.6.2",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
-    },
-    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-tokens": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
-      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
-    },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
-      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0.tgz",
+      "integrity": "sha512-V1w/j19YmOgvh72IRRf1p07k+u4M5+9P+o/IxunlF0fWzLDX4Hf+utBI11A8cRfUzpQN7eLw/vZIS3BLM8Ge3Q==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.92.8",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.8.tgz",
-      "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0.tgz",
+      "integrity": "sha512-JQ3zIl5SFiSB0YWVYibcUwgZdsp6Wn8hkfZ7KhtCjHFccSDdJexPOXVV1O9f2h4PfxTlY3YntZ81ZsguBx/Q7A=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.4.13",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.13.tgz",
-      "integrity": "sha512-cYw+pgpZXKGg3dZxudteUURqmj5O0ec7aNE80NLqFTcnI0MAOnfrFzCNApXJErn+MjD0VolMcC+H48eaRkT8TA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
+      "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
       "dependencies": {
-        "@patternfly/react-core": "^5.4.12",
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "lodash": "^4.17.21",
-        "tslib": "^2.7.0"
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
-    },
-    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-tokens": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
-      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
-    },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.94.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.7.tgz",
-      "integrity": "sha512-h+ducOLDMSxcuec3+YY3x+stM5ZUSnrl/lC/eVmjypil2El08NuE2MNEPMQWdhrod6VRRZFMNqZw/m82iv6U1A=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0.tgz",
+      "integrity": "sha512-t1UcHbOa4txczTR5UlnG4XcAAdnDSfSlCaOddw/HTqRF59pn2ks2JUu9sfnFRZ8SiAAxKRiYdX5bT7Mf4R24+w=="
     },
     "node_modules/@remix-run/router": {
       "version": "1.19.2",
@@ -6976,6 +7012,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -15528,247 +15569,362 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/victory": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.3.5.tgz",
+      "integrity": "sha512-yMvoIYi9leNF5M3X/UFzK09NItHH2UPofh51TS+EJlPY5Tf8goybfkKWJC1Sl5lpQzDK1rCFmuoX5sn959e0iw==",
+      "dependencies": {
+        "victory-area": "37.3.5",
+        "victory-axis": "37.3.5",
+        "victory-bar": "37.3.5",
+        "victory-box-plot": "37.3.5",
+        "victory-brush-container": "37.3.5",
+        "victory-brush-line": "37.3.5",
+        "victory-candlestick": "37.3.5",
+        "victory-canvas": "37.3.5",
+        "victory-chart": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-create-container": "37.3.5",
+        "victory-cursor-container": "37.3.5",
+        "victory-errorbar": "37.3.5",
+        "victory-group": "37.3.5",
+        "victory-histogram": "37.3.5",
+        "victory-legend": "37.3.5",
+        "victory-line": "37.3.5",
+        "victory-pie": "37.3.5",
+        "victory-polar-axis": "37.3.5",
+        "victory-scatter": "37.3.5",
+        "victory-selection-container": "37.3.5",
+        "victory-shared-events": "37.3.5",
+        "victory-stack": "37.3.5",
+        "victory-tooltip": "37.3.5",
+        "victory-voronoi": "37.3.5",
+        "victory-voronoi-container": "37.3.5",
+        "victory-zoom-container": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
     "node_modules/victory-area": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.9.2.tgz",
-      "integrity": "sha512-32aharvPf2RgdQB+/u1j3/ajYFNH/7ugLX9ZRpdd65gP6QEbtXL+58gS6CxvFw6gr/y8a0xMlkMKkpDVacXLpw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.5.tgz",
+      "integrity": "sha512-MP5+dm8ThQVsSDQhmU4K93mjPZ4hir1QkoM8kYT0PsJcoFYI6J2ceTxoyJUUgrgO0Kf63PcYChR5RLu34bhFlw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-axis": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.9.2.tgz",
-      "integrity": "sha512-4Odws+IAjprJtBg2b2ZCxEPgrQ6LgIOa22cFkGghzOSfTyNayN4M3AauNB44RZyn2O/hDiM1gdBkEg1g9YDevQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.5.tgz",
+      "integrity": "sha512-hd40FVZvWw26CHr6XfmVGhKgPd4I4Yqxtnl27P6aLVGv1gL46UuNVdDVFozr9rpxO+lGUepYz6Wh4OuzImpDEQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-bar": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.9.2.tgz",
-      "integrity": "sha512-R3LFoR91FzwWcnyGK2P8DHNVv9gsaWhl5pSr2KdeNtvLbZVEIvUkTeVN9RMBMzterSFPw0mbWhS1Asb3sV6PPw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.5.tgz",
+      "integrity": "sha512-9HXxM/+9jyv6SIcJv90yqyImgXLSEGhaPBnDJg5CvHcR1zdGAdQp2pDxDV6EivUrfxiIyj1NeSWyCZpM0ZJddQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.5.tgz",
+      "integrity": "sha512-jIV8k4XViLBWh5XvYBSELYGsWo55vYBoNqGkVUKhcXM4sS9mumc2XgDQ6nltTO88gs8uOyZpb2vBFp+1zOauyA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-brush-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.9.2.tgz",
-      "integrity": "sha512-KcQjzFeo40tn52cJf1A02l5MqeR9GKkk3loDqM3T2hfi1PCyUrZXEUjGN5HNlLizDRvtcemaAHNAWlb70HbG/g==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.5.tgz",
+      "integrity": "sha512-n4Ozb5I/Pz/dcWnxAfqBhnsq6Q2gIC7Phjbau3cIBTPcq/rrkRIWzpiPPWhoAT+OTirgB9vOfe3JX4LBDk17FA==",
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.3.5.tgz",
+      "integrity": "sha512-L68JolxHJo7TyH+VwMBXMKK5hAsEMe+eYCO37dO1nxU6kh6u86bkLjoc9xIN/JNOcKj9GnDEfN0rRmCdkM9wpA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.3.5.tgz",
+      "integrity": "sha512-b+NUAxhZdbd/AuZ1FVeJC+KrTMDfhSZLVoAjasFlnGTd0fpeo8ujzTNOJDjJ2aGOi/o1pLwsOr9KWWcoCdaHcA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.3.5.tgz",
+      "integrity": "sha512-8P6LZvA2p5LzJV8wklQ8oxYwep5BWUPPj1niB4vcFSJguc1dvHMtUBDofGqZJCIYi9otTabWk5VQDP/idzlu6g==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-bar": "37.3.5",
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-chart": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.9.2.tgz",
-      "integrity": "sha512-dMNcS0BpqL3YiGvI4BSEmPR76FCksCgf3K4CSZ7C/MGyrElqB6wWwzk7afnlB1Qr71YIHXDmdwsPNAl/iEwTtA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.5.tgz",
+      "integrity": "sha512-Lsbmp5rG3ESzQAr76M4WJ0FKraltAzuQY1D3e7CmqzQlLKpsMS/j2Ty+5OCBDmC3qQ+PHObBLVavgn3TJSRJLg==",
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.9.2",
-        "victory-core": "^36.9.2",
-        "victory-polar-axis": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-axis": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-polar-axis": "37.3.5",
+        "victory-shared-events": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-core": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.9.2.tgz",
-      "integrity": "sha512-AzmMy+9MYMaaRmmZZovc/Po9urHne3R3oX7bbXeQdVuK/uMBrlPiv11gVJnuEH2SXLVyep43jlKgaBp8ef9stQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.5.tgz",
+      "integrity": "sha512-PXY+9Lx1ohCX+ZzkWdm+VY7T+2Pd/YKdv3yVkuflzMQ52kQMYbcgwGI49yPuzVqB3m1eBJ5dYdAD53ww53GTHw==",
       "dependencies": {
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.9.2"
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-create-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.9.2.tgz",
-      "integrity": "sha512-uA0dh1R0YDzuXyE/7StZvq4qshet+WYceY7R1UR5mR/F9079xy+iQsa2Ca4h97/GtVZoLO6r1eKLWBt9TN+U7A==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.5.tgz",
+      "integrity": "sha512-VcHhnw35e+xU96LWwAuCZQ7YLS9NSSlGU0pgtiUUx0ymCJDWtY8G+ZijZL+DKQ5byU/8+DvaK3iNUhxdpBAHQw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.9.2",
-        "victory-core": "^36.9.2",
-        "victory-cursor-container": "^36.9.2",
-        "victory-selection-container": "^36.9.2",
-        "victory-voronoi-container": "^36.9.2",
-        "victory-zoom-container": "^36.9.2"
+        "victory-brush-container": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-cursor-container": "37.3.5",
+        "victory-selection-container": "37.3.5",
+        "victory-voronoi-container": "37.3.5",
+        "victory-zoom-container": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-cursor-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.9.2.tgz",
-      "integrity": "sha512-jidab4j3MaciF3fGX70jTj4H9rrLcY8o2LUrhJ67ZLvEFGGmnPtph+p8Fe97Umrag7E/DszjNxQZolpwlgUh3g==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.5.tgz",
+      "integrity": "sha512-/G9zpYkeJA0uBk3khGNJBUNHOZ25EPoFfVZqwSSjpVRRI3JLMVNvv1LWhZvFZDkK0KMrT8pi8AZr04jCZxCoPg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.3.5.tgz",
+      "integrity": "sha512-QYH8tn0UqtGDpOXFE8fwSmr/7Oq4VADrA1gxpMgWN9819/+vgKfBMemPdHfAguyuGftCDp7kPISvQZ1Kef19LQ==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-group": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.9.2.tgz",
-      "integrity": "sha512-wBmpsjBTKva8mxHvHNY3b8RE58KtnpLLItEyyAHaYkmExwt3Uj8Cld3sF3vmeuijn2iR64NPKeMbgMbfZJzycw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.5.tgz",
+      "integrity": "sha512-0GEtrG2Vl7uv1fkmWlHRO6U8JBhXJ3cB1KJPP2k5QKblfYd0QgDCtlSeMuaTUB+yRnQR5OlUv6bvkwwRio4bSg==",
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-shared-events": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.3.5.tgz",
+      "integrity": "sha512-2tzWguaB9/edRBG7Yyb19KZHiFlQpE5nEY3Wd9arBcG1SosQOoCNINaJ+8B1jDBdM4BGCIV/K/0ZjQEDFXlTVA==",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-legend": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.9.2.tgz",
-      "integrity": "sha512-cucFJpv6fty+yXp5pElQFQnHBk1TqA4guGUMI+XF/wLlnuM4bhdAtASobRIIBkz0mHGBaCAAV4PzL9azPU/9dg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.5.tgz",
+      "integrity": "sha512-TW/OeKP8LgZp93nJVoAltTwl5T0q1MWeH1HqZim2oGqwqX0E8o0BeJXv+2TGkXdp5ITiWi2nxGGQ77vSg8KZhQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-line": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.9.2.tgz",
-      "integrity": "sha512-kmYFZUo0o2xC8cXRsmt/oUBRQSZJVT2IJnAkboUepypoj09e6CY5tRH4TSdfEDGkBk23xQkn7d4IFgl4kAGnSA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.5.tgz",
+      "integrity": "sha512-q1L2aSG28Z7ousRckf8zut7HdLQ7kWiNakOatsdfAqnce/n52F0E8c3qSIwbRmkdHHSe3SHhTLNyzLtnDzYQjQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-pie": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.9.2.tgz",
-      "integrity": "sha512-i3zWezvy5wQEkhXKt4rS9ILGH7Vr9Q5eF9fKO4GMwDPBdYOTE3Dh2tVaSrfDC8g9zFIc0DKzOtVoJRTb+0AkPg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.5.tgz",
+      "integrity": "sha512-JjKE5QhlatZkl/YbiN2KrF+tXIHRZ0ZYua5yWl8JYcg5/UTE3IFn/Y+2HIQIGghzEa98ZMMC/lNfZ3CEwK1yaw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-polar-axis": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.9.2.tgz",
-      "integrity": "sha512-HBR90FF4M56yf/atXjSmy3DMps1vSAaLXmdVXLM/A5g+0pUS7HO719r5x6dsR3I6Rm+8x6Kk8xJs0qgpnGQIEw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.3.5.tgz",
+      "integrity": "sha512-6aZiaMGLtYDeh3uCB9wHKVVyvRsdbo5+WTp6S8lvyuHxyYOEn4JcxtpORzHHnGMWFkhZs4MmLSORrp/TBOi+7g==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-scatter": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.9.2.tgz",
-      "integrity": "sha512-hK9AtbJQfaW05i8BH7Lf1HK7vWMAfQofj23039HEQJqTKbCL77YT+Q0LhZw1a1BRCpC/5aSg9EuqblhfIYw2wg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.5.tgz",
+      "integrity": "sha512-YEXm9D1novmUjk44eFyj+UQIxUw50v3yAa/772nb8yzR9ys9xPjM9+yyIsJSbRwdSiEAPmcbj6qwcYlyvJz1bQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-selection-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.9.2.tgz",
-      "integrity": "sha512-chboroEwqqVlMB60kveXM2WznJ33ZM00PWkFVCoJDzHHlYs7TCADxzhqet2S67SbZGSyvSprY2YztSxX8kZ+XQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.5.tgz",
+      "integrity": "sha512-cGqlZwV3HAWjrXjhGUsUkyFtWn+lsph2dcUzMlzTKs+e1sDFEHIVjpe3ZX4XsThu23dK//lrmIXFvbWtpLhy+Q==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-shared-events": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.9.2.tgz",
-      "integrity": "sha512-W/atiw3Or6MnpBuhluFv6007YrixIRh5NtiRvtFLGxNuQJLYjaSh6koRAih5xJer5Pj7YUx0tL9x67jTRcJ6Dg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.5.tgz",
+      "integrity": "sha512-Juq/5Y9WsFaD/4ivk7/y786EwNgLUjp3hkhpIGhiQOM2VaL5H7Xb1pX4ASjibkCkWIQUMBM+JaprtNcKEDylpQ==",
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-stack": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.9.2.tgz",
-      "integrity": "sha512-imR6FniVlDFlBa/B3Est8kTryNhWj2ZNpivmVOebVDxkKcVlLaDg3LotCUOI7NzOhBQaro0UzeE9KmZV93JcYA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.5.tgz",
+      "integrity": "sha512-PL23dKKlr30Y77mw3JuIUYUhvOF66r3LhKQXqoymkV6DGMBhkQ2p7h+klek3xleRPBBTSz3o8EbfM8H2eZ/Umg==",
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-shared-events": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-tooltip": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.9.2.tgz",
-      "integrity": "sha512-76seo4TWD1WfZHJQH87IP3tlawv38DuwrUxpnTn8+uW6/CUex82poQiVevYdmJzhataS9jjyCWv3w7pOmLBCLg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.5.tgz",
+      "integrity": "sha512-IbvD37PGehP3K5BLL9xAK+6d/UEaNcLH/cdKKzeXeqOvoefQLIxxB1DJHYr542Ll8cxkeqtdsgtJ16pRCUgCSA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.5.tgz",
+      "integrity": "sha512-+K2VBMmB7peKG3Gjp79XjgsbfsYgD0eZRSmKz7p5a4V0NhYq43eM/b0gpSLq+Dhwag96QaWsU75/6bFVBjVE7A==",
       "dependencies": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -15786,28 +15942,41 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/victory-voronoi": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.3.5.tgz",
+      "integrity": "sha512-2bHr6ALuJZdQ+c+Zo0f1xWljM18vd3kTEZYliJXnlF3BDYr6z8FEOXDRNesjbzAa5ZbG7ZppeJP+wlOP44s6ag==",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
     "node_modules/victory-voronoi-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.9.2.tgz",
-      "integrity": "sha512-NIVYqck9N4OQnEz9mgQ4wILsci3OBWWK7RLuITGHyoD7Ne/+WH1i0Pv2y9eIx+f55rc928FUTugPPhkHvXyH3A==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.5.tgz",
+      "integrity": "sha512-GF35HQn8ACMcr7yJAFmaSKAS6w9GOsxxWoR6gtuQtBUwSBciZ5LNWpR6718nFxeOYDhkk/FVn7tnKqQTBv6XUw==",
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-tooltip": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-tooltip": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-zoom-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.9.2.tgz",
-      "integrity": "sha512-pXa2Ji6EX/pIarKT6Hcmmu2n7IG/x8Vs0D2eACQ/nbpvZa+DXWIxCRW4hcg2Va35fmXcDIEpGaX3/soXzZ+pbw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.5.tgz",
+      "integrity": "sha512-LlRp2Ulodu3rhIrM1XilgR72223+qlhXE9mzBCYVoHQ+uo8uTKt27T0iOBkvY5kRwNiXQzshn01uxUAwxyBppw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
@@ -18893,103 +19062,63 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
-      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-6.1.0.tgz",
+      "integrity": "sha512-w+QazL8NHKkg5j01eotblsswKxQQSYB0CN3yBXQL9ScpHdp/fK8M6TqWbKZNRpf+NqhMxcH/om8eR0N/fDCJqw=="
     },
     "@patternfly/react-charts": {
-      "version": "6.94.21",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.21.tgz",
-      "integrity": "sha512-/okakDxebgSacl9gnIifMjqLMGwuwqXogEIDX+TFveIGx9BBhXg+RLnSpSZS8xQMjEcSVppdz320IN2o+YgpaQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-8.1.0.tgz",
+      "integrity": "sha512-nywK5d4WLCOyw3pcSlMHcGQezyHClwzsLEegO58QMh0GvsM2DvEsylpsJdQZIE3ApMd+RVu97XZD21EQKxpIiA==",
       "requires": {
-        "@patternfly/react-styles": "^4.92.8",
-        "@patternfly/react-tokens": "^4.94.7",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.19",
-        "tslib": "^2.0.0",
-        "victory-area": "^36.6.7",
-        "victory-axis": "^36.6.7",
-        "victory-bar": "^36.6.7",
-        "victory-chart": "^36.6.7",
-        "victory-core": "^36.6.7",
-        "victory-create-container": "^36.6.7",
-        "victory-cursor-container": "^36.6.7",
-        "victory-group": "^36.6.7",
-        "victory-legend": "^36.6.7",
-        "victory-line": "^36.6.7",
-        "victory-pie": "^36.6.7",
-        "victory-scatter": "^36.6.7",
-        "victory-stack": "^36.6.7",
-        "victory-tooltip": "^36.6.7",
-        "victory-voronoi-container": "^36.6.7",
-        "victory-zoom-container": "^36.6.7"
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "lodash": "^4.17.21",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-core": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.12.tgz",
-      "integrity": "sha512-RI1xS1JGJdE/FvpkMzawaE21oeTc/e+WbxvFXqZfLhTz60P8RzVG1nYWXDL747Onkz3SYtY79PhQ8nsLeO5sJQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0.tgz",
+      "integrity": "sha512-zj0lJPZxQanXKD8ae2kYnweT0kpp1CzpHYAkaBjTrw2k6ZMfr/UPlp0/ugCjWEokBqh79RUADLkKJJPce/yoSQ==",
       "requires": {
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "focus-trap": "7.6.2",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
-      },
-      "dependencies": {
-        "@patternfly/react-styles": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-          "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
-        },
-        "@patternfly/react-tokens": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
-          "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
-        }
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-icons": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
-      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0.tgz",
+      "integrity": "sha512-V1w/j19YmOgvh72IRRf1p07k+u4M5+9P+o/IxunlF0fWzLDX4Hf+utBI11A8cRfUzpQN7eLw/vZIS3BLM8Ge3Q==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.92.8",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.8.tgz",
-      "integrity": "sha512-K4lUU8O4HiCX9NeuNUIrPgN3wlGERCxJVio+PAjd8hpJD/PKnjFfOJ9u6/Cii3qLy/5ZviWPRNHbGiwA/+YUhg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0.tgz",
+      "integrity": "sha512-JQ3zIl5SFiSB0YWVYibcUwgZdsp6Wn8hkfZ7KhtCjHFccSDdJexPOXVV1O9f2h4PfxTlY3YntZ81ZsguBx/Q7A=="
     },
     "@patternfly/react-table": {
-      "version": "5.4.13",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.13.tgz",
-      "integrity": "sha512-cYw+pgpZXKGg3dZxudteUURqmj5O0ec7aNE80NLqFTcnI0MAOnfrFzCNApXJErn+MjD0VolMcC+H48eaRkT8TA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
+      "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
       "requires": {
-        "@patternfly/react-core": "^5.4.12",
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
         "lodash": "^4.17.21",
-        "tslib": "^2.7.0"
-      },
-      "dependencies": {
-        "@patternfly/react-styles": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-          "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
-        },
-        "@patternfly/react-tokens": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
-          "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
-        }
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.94.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.7.tgz",
-      "integrity": "sha512-h+ducOLDMSxcuec3+YY3x+stM5ZUSnrl/lC/eVmjypil2El08NuE2MNEPMQWdhrod6VRRZFMNqZw/m82iv6U1A=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0.tgz",
+      "integrity": "sha512-t1UcHbOa4txczTR5UlnG4XcAAdnDSfSlCaOddw/HTqRF59pn2ks2JUu9sfnFRZ8SiAAxKRiYdX5bT7Mf4R24+w=="
     },
     "@remix-run/router": {
       "version": "1.19.2",
@@ -21644,6 +21773,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -27751,193 +27885,287 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "victory": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.3.5.tgz",
+      "integrity": "sha512-yMvoIYi9leNF5M3X/UFzK09NItHH2UPofh51TS+EJlPY5Tf8goybfkKWJC1Sl5lpQzDK1rCFmuoX5sn959e0iw==",
+      "requires": {
+        "victory-area": "37.3.5",
+        "victory-axis": "37.3.5",
+        "victory-bar": "37.3.5",
+        "victory-box-plot": "37.3.5",
+        "victory-brush-container": "37.3.5",
+        "victory-brush-line": "37.3.5",
+        "victory-candlestick": "37.3.5",
+        "victory-canvas": "37.3.5",
+        "victory-chart": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-create-container": "37.3.5",
+        "victory-cursor-container": "37.3.5",
+        "victory-errorbar": "37.3.5",
+        "victory-group": "37.3.5",
+        "victory-histogram": "37.3.5",
+        "victory-legend": "37.3.5",
+        "victory-line": "37.3.5",
+        "victory-pie": "37.3.5",
+        "victory-polar-axis": "37.3.5",
+        "victory-scatter": "37.3.5",
+        "victory-selection-container": "37.3.5",
+        "victory-shared-events": "37.3.5",
+        "victory-stack": "37.3.5",
+        "victory-tooltip": "37.3.5",
+        "victory-voronoi": "37.3.5",
+        "victory-voronoi-container": "37.3.5",
+        "victory-zoom-container": "37.3.5"
+      }
+    },
     "victory-area": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.9.2.tgz",
-      "integrity": "sha512-32aharvPf2RgdQB+/u1j3/ajYFNH/7ugLX9ZRpdd65gP6QEbtXL+58gS6CxvFw6gr/y8a0xMlkMKkpDVacXLpw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.5.tgz",
+      "integrity": "sha512-MP5+dm8ThQVsSDQhmU4K93mjPZ4hir1QkoM8kYT0PsJcoFYI6J2ceTxoyJUUgrgO0Kf63PcYChR5RLu34bhFlw==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-axis": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.9.2.tgz",
-      "integrity": "sha512-4Odws+IAjprJtBg2b2ZCxEPgrQ6LgIOa22cFkGghzOSfTyNayN4M3AauNB44RZyn2O/hDiM1gdBkEg1g9YDevQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.5.tgz",
+      "integrity": "sha512-hd40FVZvWw26CHr6XfmVGhKgPd4I4Yqxtnl27P6aLVGv1gL46UuNVdDVFozr9rpxO+lGUepYz6Wh4OuzImpDEQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-bar": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.9.2.tgz",
-      "integrity": "sha512-R3LFoR91FzwWcnyGK2P8DHNVv9gsaWhl5pSr2KdeNtvLbZVEIvUkTeVN9RMBMzterSFPw0mbWhS1Asb3sV6PPw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.5.tgz",
+      "integrity": "sha512-9HXxM/+9jyv6SIcJv90yqyImgXLSEGhaPBnDJg5CvHcR1zdGAdQp2pDxDV6EivUrfxiIyj1NeSWyCZpM0ZJddQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
+      }
+    },
+    "victory-box-plot": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.5.tgz",
+      "integrity": "sha512-jIV8k4XViLBWh5XvYBSELYGsWo55vYBoNqGkVUKhcXM4sS9mumc2XgDQ6nltTO88gs8uOyZpb2vBFp+1zOauyA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-brush-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.9.2.tgz",
-      "integrity": "sha512-KcQjzFeo40tn52cJf1A02l5MqeR9GKkk3loDqM3T2hfi1PCyUrZXEUjGN5HNlLizDRvtcemaAHNAWlb70HbG/g==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.5.tgz",
+      "integrity": "sha512-n4Ozb5I/Pz/dcWnxAfqBhnsq6Q2gIC7Phjbau3cIBTPcq/rrkRIWzpiPPWhoAT+OTirgB9vOfe3JX4LBDk17FA==",
       "requires": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
+      }
+    },
+    "victory-brush-line": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.3.5.tgz",
+      "integrity": "sha512-L68JolxHJo7TyH+VwMBXMKK5hAsEMe+eYCO37dO1nxU6kh6u86bkLjoc9xIN/JNOcKj9GnDEfN0rRmCdkM9wpA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.5"
+      }
+    },
+    "victory-candlestick": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.3.5.tgz",
+      "integrity": "sha512-b+NUAxhZdbd/AuZ1FVeJC+KrTMDfhSZLVoAjasFlnGTd0fpeo8ujzTNOJDjJ2aGOi/o1pLwsOr9KWWcoCdaHcA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
+      }
+    },
+    "victory-canvas": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.3.5.tgz",
+      "integrity": "sha512-8P6LZvA2p5LzJV8wklQ8oxYwep5BWUPPj1niB4vcFSJguc1dvHMtUBDofGqZJCIYi9otTabWk5VQDP/idzlu6g==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-bar": "37.3.5",
+        "victory-core": "37.3.5"
       }
     },
     "victory-chart": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.9.2.tgz",
-      "integrity": "sha512-dMNcS0BpqL3YiGvI4BSEmPR76FCksCgf3K4CSZ7C/MGyrElqB6wWwzk7afnlB1Qr71YIHXDmdwsPNAl/iEwTtA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.5.tgz",
+      "integrity": "sha512-Lsbmp5rG3ESzQAr76M4WJ0FKraltAzuQY1D3e7CmqzQlLKpsMS/j2Ty+5OCBDmC3qQ+PHObBLVavgn3TJSRJLg==",
       "requires": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.9.2",
-        "victory-core": "^36.9.2",
-        "victory-polar-axis": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-axis": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-polar-axis": "37.3.5",
+        "victory-shared-events": "37.3.5"
       }
     },
     "victory-core": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.9.2.tgz",
-      "integrity": "sha512-AzmMy+9MYMaaRmmZZovc/Po9urHne3R3oX7bbXeQdVuK/uMBrlPiv11gVJnuEH2SXLVyep43jlKgaBp8ef9stQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.5.tgz",
+      "integrity": "sha512-PXY+9Lx1ohCX+ZzkWdm+VY7T+2Pd/YKdv3yVkuflzMQ52kQMYbcgwGI49yPuzVqB3m1eBJ5dYdAD53ww53GTHw==",
       "requires": {
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.9.2"
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-create-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.9.2.tgz",
-      "integrity": "sha512-uA0dh1R0YDzuXyE/7StZvq4qshet+WYceY7R1UR5mR/F9079xy+iQsa2Ca4h97/GtVZoLO6r1eKLWBt9TN+U7A==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.5.tgz",
+      "integrity": "sha512-VcHhnw35e+xU96LWwAuCZQ7YLS9NSSlGU0pgtiUUx0ymCJDWtY8G+ZijZL+DKQ5byU/8+DvaK3iNUhxdpBAHQw==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.9.2",
-        "victory-core": "^36.9.2",
-        "victory-cursor-container": "^36.9.2",
-        "victory-selection-container": "^36.9.2",
-        "victory-voronoi-container": "^36.9.2",
-        "victory-zoom-container": "^36.9.2"
+        "victory-brush-container": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-cursor-container": "37.3.5",
+        "victory-selection-container": "37.3.5",
+        "victory-voronoi-container": "37.3.5",
+        "victory-zoom-container": "37.3.5"
       }
     },
     "victory-cursor-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.9.2.tgz",
-      "integrity": "sha512-jidab4j3MaciF3fGX70jTj4H9rrLcY8o2LUrhJ67ZLvEFGGmnPtph+p8Fe97Umrag7E/DszjNxQZolpwlgUh3g==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.5.tgz",
+      "integrity": "sha512-/G9zpYkeJA0uBk3khGNJBUNHOZ25EPoFfVZqwSSjpVRRI3JLMVNvv1LWhZvFZDkK0KMrT8pi8AZr04jCZxCoPg==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
+      }
+    },
+    "victory-errorbar": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.3.5.tgz",
+      "integrity": "sha512-QYH8tn0UqtGDpOXFE8fwSmr/7Oq4VADrA1gxpMgWN9819/+vgKfBMemPdHfAguyuGftCDp7kPISvQZ1Kef19LQ==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
       }
     },
     "victory-group": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.9.2.tgz",
-      "integrity": "sha512-wBmpsjBTKva8mxHvHNY3b8RE58KtnpLLItEyyAHaYkmExwt3Uj8Cld3sF3vmeuijn2iR64NPKeMbgMbfZJzycw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.5.tgz",
+      "integrity": "sha512-0GEtrG2Vl7uv1fkmWlHRO6U8JBhXJ3cB1KJPP2k5QKblfYd0QgDCtlSeMuaTUB+yRnQR5OlUv6bvkwwRio4bSg==",
       "requires": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-shared-events": "37.3.5"
+      }
+    },
+    "victory-histogram": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.3.5.tgz",
+      "integrity": "sha512-2tzWguaB9/edRBG7Yyb19KZHiFlQpE5nEY3Wd9arBcG1SosQOoCNINaJ+8B1jDBdM4BGCIV/K/0ZjQEDFXlTVA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "37.3.5",
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-legend": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.9.2.tgz",
-      "integrity": "sha512-cucFJpv6fty+yXp5pElQFQnHBk1TqA4guGUMI+XF/wLlnuM4bhdAtASobRIIBkz0mHGBaCAAV4PzL9azPU/9dg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.5.tgz",
+      "integrity": "sha512-TW/OeKP8LgZp93nJVoAltTwl5T0q1MWeH1HqZim2oGqwqX0E8o0BeJXv+2TGkXdp5ITiWi2nxGGQ77vSg8KZhQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-line": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.9.2.tgz",
-      "integrity": "sha512-kmYFZUo0o2xC8cXRsmt/oUBRQSZJVT2IJnAkboUepypoj09e6CY5tRH4TSdfEDGkBk23xQkn7d4IFgl4kAGnSA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.5.tgz",
+      "integrity": "sha512-q1L2aSG28Z7ousRckf8zut7HdLQ7kWiNakOatsdfAqnce/n52F0E8c3qSIwbRmkdHHSe3SHhTLNyzLtnDzYQjQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-pie": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.9.2.tgz",
-      "integrity": "sha512-i3zWezvy5wQEkhXKt4rS9ILGH7Vr9Q5eF9fKO4GMwDPBdYOTE3Dh2tVaSrfDC8g9zFIc0DKzOtVoJRTb+0AkPg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.5.tgz",
+      "integrity": "sha512-JjKE5QhlatZkl/YbiN2KrF+tXIHRZ0ZYua5yWl8JYcg5/UTE3IFn/Y+2HIQIGghzEa98ZMMC/lNfZ3CEwK1yaw==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2",
-        "victory-vendor": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-vendor": "37.3.5"
       }
     },
     "victory-polar-axis": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.9.2.tgz",
-      "integrity": "sha512-HBR90FF4M56yf/atXjSmy3DMps1vSAaLXmdVXLM/A5g+0pUS7HO719r5x6dsR3I6Rm+8x6Kk8xJs0qgpnGQIEw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.3.5.tgz",
+      "integrity": "sha512-6aZiaMGLtYDeh3uCB9wHKVVyvRsdbo5+WTp6S8lvyuHxyYOEn4JcxtpORzHHnGMWFkhZs4MmLSORrp/TBOi+7g==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-scatter": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.9.2.tgz",
-      "integrity": "sha512-hK9AtbJQfaW05i8BH7Lf1HK7vWMAfQofj23039HEQJqTKbCL77YT+Q0LhZw1a1BRCpC/5aSg9EuqblhfIYw2wg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.5.tgz",
+      "integrity": "sha512-YEXm9D1novmUjk44eFyj+UQIxUw50v3yAa/772nb8yzR9ys9xPjM9+yyIsJSbRwdSiEAPmcbj6qwcYlyvJz1bQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-selection-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.9.2.tgz",
-      "integrity": "sha512-chboroEwqqVlMB60kveXM2WznJ33ZM00PWkFVCoJDzHHlYs7TCADxzhqet2S67SbZGSyvSprY2YztSxX8kZ+XQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.5.tgz",
+      "integrity": "sha512-cGqlZwV3HAWjrXjhGUsUkyFtWn+lsph2dcUzMlzTKs+e1sDFEHIVjpe3ZX4XsThu23dK//lrmIXFvbWtpLhy+Q==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-shared-events": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.9.2.tgz",
-      "integrity": "sha512-W/atiw3Or6MnpBuhluFv6007YrixIRh5NtiRvtFLGxNuQJLYjaSh6koRAih5xJer5Pj7YUx0tL9x67jTRcJ6Dg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.5.tgz",
+      "integrity": "sha512-Juq/5Y9WsFaD/4ivk7/y786EwNgLUjp3hkhpIGhiQOM2VaL5H7Xb1pX4ASjibkCkWIQUMBM+JaprtNcKEDylpQ==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-stack": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.9.2.tgz",
-      "integrity": "sha512-imR6FniVlDFlBa/B3Est8kTryNhWj2ZNpivmVOebVDxkKcVlLaDg3LotCUOI7NzOhBQaro0UzeE9KmZV93JcYA==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.5.tgz",
+      "integrity": "sha512-PL23dKKlr30Y77mw3JuIUYUhvOF66r3LhKQXqoymkV6DGMBhkQ2p7h+klek3xleRPBBTSz3o8EbfM8H2eZ/Umg==",
       "requires": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-shared-events": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-shared-events": "37.3.5"
       }
     },
     "victory-tooltip": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.9.2.tgz",
-      "integrity": "sha512-76seo4TWD1WfZHJQH87IP3tlawv38DuwrUxpnTn8+uW6/CUex82poQiVevYdmJzhataS9jjyCWv3w7pOmLBCLg==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.5.tgz",
+      "integrity": "sha512-IbvD37PGehP3K5BLL9xAK+6d/UEaNcLH/cdKKzeXeqOvoefQLIxxB1DJHYr542Ll8cxkeqtdsgtJ16pRCUgCSA==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.5.tgz",
+      "integrity": "sha512-+K2VBMmB7peKG3Gjp79XjgsbfsYgD0eZRSmKz7p5a4V0NhYq43eM/b0gpSLq+Dhwag96QaWsU75/6bFVBjVE7A==",
       "requires": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -27955,25 +28183,35 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "victory-voronoi": {
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.3.5.tgz",
+      "integrity": "sha512-2bHr6ALuJZdQ+c+Zo0f1xWljM18vd3kTEZYliJXnlF3BDYr6z8FEOXDRNesjbzAa5ZbG7ZppeJP+wlOP44s6ag==",
+      "requires": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.5"
+      }
+    },
     "victory-voronoi-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.9.2.tgz",
-      "integrity": "sha512-NIVYqck9N4OQnEz9mgQ4wILsci3OBWWK7RLuITGHyoD7Ne/+WH1i0Pv2y9eIx+f55rc928FUTugPPhkHvXyH3A==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.5.tgz",
+      "integrity": "sha512-GF35HQn8ACMcr7yJAFmaSKAS6w9GOsxxWoR6gtuQtBUwSBciZ5LNWpR6718nFxeOYDhkk/FVn7tnKqQTBv6XUw==",
       "requires": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.9.2",
-        "victory-tooltip": "^36.9.2"
+        "victory-core": "37.3.5",
+        "victory-tooltip": "37.3.5"
       }
     },
     "victory-zoom-container": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.9.2.tgz",
-      "integrity": "sha512-pXa2Ji6EX/pIarKT6Hcmmu2n7IG/x8Vs0D2eACQ/nbpvZa+DXWIxCRW4hcg2Va35fmXcDIEpGaX3/soXzZ+pbw==",
+      "version": "37.3.5",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.5.tgz",
+      "integrity": "sha512-LlRp2Ulodu3rhIrM1XilgR72223+qlhXE9mzBCYVoHQ+uo8uTKt27T0iOBkvY5kRwNiXQzshn01uxUAwxyBppw==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-core": "^36.9.2"
+        "victory-core": "37.3.5"
       }
     },
     "vinyl": {

--- a/web/package.json
+++ b/web/package.json
@@ -99,11 +99,11 @@
   },
   "dependencies": {
     "@grafana/lezer-logql": "^0.2.6",
-    "@patternfly/patternfly": "4.215.1",
-    "@patternfly/react-charts": "6.92.0",
-    "@patternfly/react-core": "4.239.0",
-    "@patternfly/react-icons": "^4.57.2",
-    "@patternfly/react-table": "4.108.0",
+    "@patternfly/patternfly": "^5.4.2",
+    "@patternfly/react-charts": "^6.94.21",
+    "@patternfly/react-core": "^5.4.12",
+    "@patternfly/react-icons": "^5.4.2",
+    "@patternfly/react-table": "^5.4.13",
     "i18next": "^22.4.12",
     "react-i18next": "^11.18.6"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -99,13 +99,15 @@
   },
   "dependencies": {
     "@grafana/lezer-logql": "^0.2.6",
-    "@patternfly/patternfly": "^5.4.2",
-    "@patternfly/react-charts": "^6.94.21",
-    "@patternfly/react-core": "^5.4.12",
-    "@patternfly/react-icons": "^5.4.2",
-    "@patternfly/react-table": "^5.4.13",
+    "@patternfly/patternfly": "^6.1.0",
+    "@patternfly/react-charts": "^8.1.0",
+    "@patternfly/react-core": "^6.1.0",
+    "@patternfly/react-icons": "^6.1.0",
+    "@patternfly/react-table": "^6.1.0",
+    "@patternfly/react-tokens": "^6.1.0",
     "i18next": "^22.4.12",
-    "react-i18next": "^11.18.6"
+    "react-i18next": "^11.18.6",
+    "victory": "^37.3.5"
   },
   "nyc": {
     "report-dir": "./coverage/cov-cypress"

--- a/web/src/components/alerts/logs-alerts-metrics.css
+++ b/web/src/components/alerts/logs-alerts-metrics.css
@@ -1,11 +1,11 @@
 .co-logs-alert-metrics__container {
-  border: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-  margin: 0 0 var(--pf-global--spacer--md) 0;
-  padding: var(--pf-global--spacer--sm);
+  border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
+  margin: 0 0 var(--pf-v5-global--spacer--md) 0;
+  padding: var(--pf-v5-global--spacer--sm);
 }
 
 .co-logs-metrics__header {
-  margin-bottom: var(--pf-global--spacer--sm);
+  margin-bottom: var(--pf-v5-global--spacer--sm);
 }
 
 .co-logs-metrics__error {

--- a/web/src/components/error-message.css
+++ b/web/src/components/error-message.css
@@ -1,9 +1,9 @@
 .co-logs-error_message {
-  margin-bottom: var(--pf-global--spacer--md);
-  margin-top: var(--pf-global--spacer--md);
+  margin-bottom: var(--pf-v5-global--spacer--md);
+  margin-top: var(--pf-v5-global--spacer--md);
   background-color: transparent;
 }
 
-.co-logs-table__row-error .pf-c-code-block__pre {
+.co-logs-table__row-error .pf-v5-c-code-block__pre {
   text-align: left;
 }

--- a/web/src/components/error-message.css
+++ b/web/src/components/error-message.css
@@ -4,6 +4,6 @@
   background-color: transparent;
 }
 
-.co-logs-table__row-error .pf-v5-c-code-block__pre {
+.co-logs-table__row-error .pf-v6-c-code-block__pre {
   text-align: left;
 }

--- a/web/src/components/error-message.tsx
+++ b/web/src/components/error-message.tsx
@@ -1,11 +1,4 @@
-import {
-  Alert,
-  CodeBlock,
-  CodeBlockCode,
-  Text,
-  TextContent,
-  TextVariants,
-} from '@patternfly/react-core';
+import { Alert, CodeBlock, CodeBlockCode, Content, ContentVariants } from '@patternfly/react-core';
 import React from 'react';
 import { TFunction, useTranslation } from 'react-i18next';
 import { isFetchError } from '../cancellable-fetch';
@@ -32,7 +25,7 @@ subjects:
 `;
 
 const Suggestion: React.FC = ({ children }) => (
-  <Text component={TextVariants.small}>{children}</Text>
+  <Content component={ContentVariants.small}>{children}</Content>
 );
 
 const messages: (t: TFunction) => Record<string, React.ReactElement> = (t) => ({
@@ -138,11 +131,11 @@ export const ErrorMessage: React.FC<ErrorMessageProps> = ({ error }) => {
       />
 
       {suggestions && suggestions.length > 0 ? (
-        <TextContent>
-          <Text component={TextVariants.p}>{title}</Text>
+        <Content>
+          <Content component={ContentVariants.p}>{title}</Content>
 
           {suggestions}
-        </TextContent>
+        </Content>
       ) : null}
     </>
   );

--- a/web/src/components/filters/attribute-filter.css
+++ b/web/src/components/filters/attribute-filter.css
@@ -1,4 +1,4 @@
-.co-logs__attribute-filter .pf-c-select__toggle-wrapper {
+.co-logs__attribute-filter .pf-v5-c-select__toggle-wrapper {
   flex-wrap: nowrap;
 }
 

--- a/web/src/components/filters/attribute-filter.css
+++ b/web/src/components/filters/attribute-filter.css
@@ -1,4 +1,4 @@
-.co-logs__attribute-filter .pf-v5-c-select__toggle-wrapper {
+.co-logs__attribute-filter .pf-v6-c-select__toggle-wrapper {
   flex-wrap: nowrap;
 }
 

--- a/web/src/components/filters/attribute-filter.tsx
+++ b/web/src/components/filters/attribute-filter.tsx
@@ -6,8 +6,8 @@ import {
   SelectList,
   SelectOption,
   TextInput,
-  ToolbarChip,
-  ToolbarChipGroup,
+  ToolbarLabel,
+  ToolbarLabelGroup,
   ToolbarFilter,
   ToolbarGroup,
 } from '@patternfly/react-core';
@@ -109,7 +109,7 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
   };
 
   const handleDeleteAttributeValue =
-    (attribute: string) => (_category: string | ToolbarChipGroup, chip: string | ToolbarChip) => {
+    (attribute: string) => (_category: string | ToolbarLabelGroup, chip: string | ToolbarLabel) => {
       filters?.[attribute]?.delete(chip as string);
       onFiltersChange?.({
         ...filters,
@@ -204,9 +204,9 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
         {attributeList.map((attribute) => (
           <ToolbarFilter
             key={`toolbar-filter-${attribute.id}`}
-            chips={Array.from(filters[attribute.id] ?? [])}
-            deleteChip={handleDeleteAttributeValue(attribute.id)}
-            deleteChipGroup={handleDeleteAttributeGroup(attribute.id)}
+            labels={Array.from(filters[attribute.id] ?? [])}
+            deleteLabel={handleDeleteAttributeValue(attribute.id)}
+            deleteLabelGroup={handleDeleteAttributeGroup(attribute.id)}
             categoryName={attribute.name}
             data-test={'test'}
           >

--- a/web/src/components/filters/attribute-filter.tsx
+++ b/web/src/components/filters/attribute-filter.tsx
@@ -1,8 +1,10 @@
 import {
+  Badge,
+  MenuToggle,
+  MenuToggleElement,
   Select,
+  SelectList,
   SelectOption,
-  SelectOptionObject,
-  SelectVariant,
   TextInput,
   ToolbarChip,
   ToolbarChipGroup,
@@ -58,8 +60,8 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
   }, [textAttribute, filters]);
 
   const handleAttributeSelect = (
-    _: React.MouseEvent | React.ChangeEvent,
-    value: string | SelectOptionObject,
+    _: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
   ) => {
     if (typeof value === 'string') {
       setSelectedAttributeId(value);
@@ -120,6 +122,24 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
     setTextInputValue(value);
   };
 
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={handleAttributeToggle}
+      isExpanded={isAttributeExpanded}
+      isDisabled={isDisabled}
+      icon={<FilterIcon />}
+      style={
+        {
+          width: '200px',
+        } as React.CSSProperties
+      }
+    >
+      Filter by status
+      {attributeList.length > 0 && <Badge isRead>{attributeList.length}</Badge>}
+    </MenuToggle>
+  );
+
   const renderAttributeValueComponent = (attribute: Attribute) => {
     switch (attribute.valueType) {
       case 'text': {
@@ -129,9 +149,8 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
             placeholder={t('Search by {{attributeName}}', {
               attributeName: attribute.name,
             })}
-            onChange={handleInputValueChange}
+            onChange={(_event, value: string) => handleInputValueChange(value)}
             className="co-logs__attribute-filter__text"
-            iconVariant="search"
             aria-label={t('Search by {{attributeName}}', {
               attributeName: attribute.name,
             })}
@@ -153,9 +172,9 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
           <SearchSelect
             key={`checkbox-select-${attribute.id}`}
             attribute={attribute}
-            variant={SelectVariant.checkbox}
             onSelect={handleAttributeValueChange}
             filters={filters}
+            isCheckbox={true}
           />
         );
     }
@@ -169,19 +188,18 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
         data-test={TestIds.AttributeFilters}
       >
         <Select
-          onToggle={handleAttributeToggle}
           isOpen={isAttributeExpanded}
           onSelect={handleAttributeSelect}
-          placeholderText={t('Attribute')}
-          isDisabled={isDisabled}
-          selections={selectedAttributeId}
-          toggleIcon={<FilterIcon />}
+          placeholder={t('Attribute')}
+          toggle={toggle}
         >
-          {attributeList.map(({ name: label, id }) => (
-            <SelectOption key={id} value={id}>
-              {label}
-            </SelectOption>
-          ))}
+          <SelectList>
+            {attributeList.map(({ name: label, id }) => (
+              <SelectOption key={id} value={id} isSelected={selectedAttributeId === id}>
+                {label}
+              </SelectOption>
+            ))}
+          </SelectList>
         </Select>
         {attributeList.map((attribute) => (
           <ToolbarFilter

--- a/web/src/components/filters/search-select.css
+++ b/web/src/components/filters/search-select.css
@@ -1,4 +1,4 @@
-.co-logs__search-select .pf-v5-c-form__fieldset {
+.co-logs__search-select .pf-v6-c-form__fieldset {
   max-height: 50vh;
   overflow: auto;
 }

--- a/web/src/components/filters/search-select.css
+++ b/web/src/components/filters/search-select.css
@@ -1,4 +1,4 @@
-.co-logs__search-select .pf-c-form__fieldset {
+.co-logs__search-select .pf-v5-c-form__fieldset {
   max-height: 50vh;
   overflow: auto;
 }

--- a/web/src/components/log-detail.css
+++ b/web/src/components/log-detail.css
@@ -1,5 +1,5 @@
-.pf-c-description-list.pf-m-compact.co-logs-detail_descripton-list{
-  --pf-c-description-list--RowGap: var(--pf-global--spacer--sm);
+.pf-v5-c-description-list.pf-m-compact.co-logs-detail_descripton-list{
+  --pf-v5-c-description-list--RowGap: var(--pf-v5-global--spacer--sm);
 }
 
 .co-logs-detail__list-term{

--- a/web/src/components/log-detail.css
+++ b/web/src/components/log-detail.css
@@ -1,4 +1,4 @@
-.pf-v5-c-description-list.pf-m-compact.co-logs-detail_descripton-list{
+.pf-v6-c-description-list.pf-m-compact.co-logs-detail_descripton-list{
   --pf-v5-c-description-list--RowGap: var(--pf-v5-global--spacer--sm);
 }
 

--- a/web/src/components/logs-histogram.css
+++ b/web/src/components/logs-histogram.css
@@ -1,4 +1,4 @@
 .co-logs-histogram__tooltip-line{
-  stroke: var(--pf-global--BackgroundColor--dark-100);
+  stroke: var(--pf-v5-global--BackgroundColor--dark-100);
   stroke-dasharray: 3;
 }

--- a/web/src/components/logs-histogram.tsx
+++ b/web/src/components/logs-histogram.tsx
@@ -6,7 +6,7 @@ import {
   ChartLegendTooltipProps,
   ChartStack,
   createContainer,
-} from '@patternfly/react-charts';
+} from '@patternfly/react-charts/victory';
 import { getResizeObserver } from '@patternfly/react-core';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import React from 'react';
@@ -25,6 +25,7 @@ import { intervalFromTimeRange, numericTimeRange } from '../time-range';
 import { valueWithScalePrefix } from '../value-utils';
 import { CenteredContainer } from './centered-container';
 import './logs-histogram.css';
+import { CallbackArgs } from 'victory';
 
 const GRAPH_HEIGHT = 130;
 const LEFT_PADDING = 50;
@@ -172,7 +173,9 @@ const HistogramTooltip: React.FC<ChartLegendTooltipProps & { interval: number }>
     <>
       <ChartLegendTooltip
         {...fixedProps}
-        title={(datum: ChartData) => dateToFormat(datum.x, getTimeFormatFromInterval(interval))}
+        title={(datum: CallbackArgs) =>
+          dateToFormat(Number(datum.x), getTimeFormatFromInterval(interval))
+        }
         constrainToVisibleArea
       />
       <line

--- a/web/src/components/logs-histogram.tsx
+++ b/web/src/components/logs-histogram.tsx
@@ -6,8 +6,8 @@ import {
   ChartLegendTooltipProps,
   ChartStack,
   createContainer,
-  getResizeObserver,
 } from '@patternfly/react-charts';
+import { getResizeObserver } from '@patternfly/react-core';
 import { Alert, Card, CardBody } from '@patternfly/react-core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -207,13 +207,13 @@ const BrushHandleComponent: React.FC<SelectionComponentProps> = ({ x, y, width, 
         x2={x}
         y1={y}
         y2={height + y}
-        style={{ stroke: 'var(--pf-chart-color-blue-300)', strokeDasharray: '5 3' }}
+        style={{ stroke: 'var(--pf-v5-chart-color-blue-300)', strokeDasharray: '5 3' }}
       />
       <polygon
         points={`${x},${y} ${x - triangleSize},${y - triangleSize} ${x + triangleSize},${
           y - triangleSize
         }`}
-        style={{ fill: 'var(--pf-chart-color-blue-300)' }}
+        style={{ fill: 'var(--pf-v5-chart-color-blue-300)' }}
       />
     </g>
   );

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -6,8 +6,7 @@ import {
   ChartLine,
   ChartThemeColor,
   createContainer,
-  getThemeColors,
-} from '@patternfly/react-charts';
+} from '@patternfly/react-charts/victory';
 import { Alert } from '@patternfly/react-core';
 import { InnerScrollContainer, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import React from 'react';
@@ -19,8 +18,8 @@ import { TestIds } from '../test-ids';
 import { defaultTimeRange, intervalFromTimeRange, numericTimeRange } from '../time-range';
 import { CenteredContainer } from './centered-container';
 import './logs-metrics.css';
-
-const colors = getThemeColors(ChartThemeColor.multiUnordered).line.colorScale;
+import t_global_background_color_secondary_default from '@patternfly/react-tokens/dist/esm/t_global_background_color_secondary_default';
+import { CallbackArgs } from 'victory';
 
 type MetricsData = {
   name: string;
@@ -182,8 +181,8 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
                 labelComponent={
                   <ChartLegendTooltip
                     legendData={toolTipData}
-                    title={(datum: { x: number }) =>
-                      dateToFormat(datum.x, getTimeFormatFromTimeRange(timeRangeValue))
+                    title={(datum: CallbackArgs) =>
+                      dateToFormat(Number(datum.x), getTimeFormatFromTimeRange(timeRangeValue))
                     }
                   />
                 }
@@ -237,19 +236,26 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {legendTableData?.map((series, index) => (
-                    <Tr key={series.childName}>
-                      <Th isStickyColumn stickyMinWidth="20px" style={{ width: '20px' }}>
-                        <div
-                          className="co-logs-metrics-legent-table-color"
-                          style={{ backgroundColor: colors[index] }}
-                        />
-                      </Th>
-                      {legendTableColumns.map((column) => (
-                        <Td key={`${column}-${index}`}>{series.labels[column]}</Td>
-                      ))}
-                    </Tr>
-                  ))}
+                  {legendTableData?.map((series, index) => {
+                    const isOddRow = (index + 1) % 2;
+                    const customStyle = {
+                      backgroundColor: t_global_background_color_secondary_default.var,
+                    };
+                    return (
+                      <Tr
+                        key={series.childName}
+                        className={isOddRow ? 'odd-row-class' : 'even-row-class'}
+                        style={isOddRow ? customStyle : {}}
+                      >
+                        <Th isStickyColumn stickyMinWidth="20px" style={{ width: '20px' }}>
+                          <div className="co-logs-metrics-legent-table-color" />
+                        </Th>
+                        {legendTableColumns.map((column) => (
+                          <Td key={`${column}-${index}`}>{series.labels[column]}</Td>
+                        ))}
+                      </Tr>
+                    );
+                  })}
                 </Tbody>
               </Table>
             </InnerScrollContainer>

--- a/web/src/components/logs-query-input.css
+++ b/web/src/components/logs-query-input.css
@@ -8,7 +8,7 @@
   width: 100%;
 }
 
-textarea.pf-v5-c-form-control.co-logs-expression-input__searchInput {
+textarea.pf-v6-c-form-control.co-logs-expression-input__searchInput {
   font-family: var(--pf-v5-c-code-block__pre--FontFamily), monospace;
   font-size: var(--pf-v5-c-code-block__pre--FontSize);
 }

--- a/web/src/components/logs-query-input.css
+++ b/web/src/components/logs-query-input.css
@@ -4,15 +4,15 @@
 }
 
 .co-logs-expression-input__form {
-  margin-right: var(--pf-global--spacer--md);
+  margin-right: var(--pf-v5-global--spacer--md);
   width: 100%;
 }
 
-textarea.pf-c-form-control.co-logs-expression-input__searchInput {
-  font-family: var(--pf-c-code-block__pre--FontFamily), monospace;
-  font-size: var(--pf-c-code-block__pre--FontSize);
+textarea.pf-v5-c-form-control.co-logs-expression-input__searchInput {
+  font-family: var(--pf-v5-c-code-block__pre--FontFamily), monospace;
+  font-size: var(--pf-v5-c-code-block__pre--FontSize);
 }
 
 .co-logs-expression-input__volumeButton{
-  margin-left: var(--pf-global--spacer--md);
+  margin-left: var(--pf-v5-global--spacer--md);
 }

--- a/web/src/components/logs-query-input.tsx
+++ b/web/src/components/logs-query-input.tsx
@@ -1,4 +1,4 @@
-import { Form, FormGroup, TextArea } from '@patternfly/react-core';
+import { Alert, Form, FormAlert, FormGroup, TextArea } from '@patternfly/react-core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { LogQLQuery } from '../logql-query';
@@ -56,23 +56,28 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
   return (
     <div className="co-logs-expression-input" data-test={TestIds.LogsQueryInput}>
       <Form className="co-logs-expression-input__form">
-        <FormGroup
-          type="string"
-          helperTextInvalid={
-            !isValid
-              ? `${t(
-                  'Invalid log stream selector. Please select a namespace, pod or container as filter, or add a log stream selector like: ',
-                )} { log_type =~ ".+" } | json`
-              : invalidQueryErrorMessage
-          }
-          fieldId="selection"
-          validated={hasError ? 'error' : undefined}
-        >
+        {hasError && (
+          <FormAlert>
+            <Alert
+              variant="danger"
+              title={
+                !isValid
+                  ? `${t(
+                      'Invalid log stream selector. Please select a namespace, pod or container as filter, or add a log stream selector like: ',
+                    )} { log_type =~ ".+" } | json`
+                  : invalidQueryErrorMessage
+              }
+              aria-live="polite"
+              isInline
+            />
+          </FormAlert>
+        )}
+        <FormGroup type="string" fieldId="selection">
           <TextArea
             className="co-logs-expression-input__searchInput"
             placeholder="LogQL Query"
             value={internalValue}
-            onChange={handleOnChange}
+            onChange={(_event, text: string) => handleOnChange(text)}
             onKeyDown={handleKeyDown}
             aria-label="LogQL Query"
             validated={hasError ? 'error' : undefined}

--- a/web/src/components/logs-table.css
+++ b/web/src/components/logs-table.css
@@ -3,7 +3,7 @@
 }
 
 .co-logs-table__time {
-  --pf-c-table--cell--WhiteSpace: nowrap;
+  --pf-v5-c-table--cell--WhiteSpace: nowrap;
   font-family: monospace;
 }
 
@@ -13,8 +13,8 @@
 }
 
 .co-logs-table__resources {
-  --pf-c-table--cell--FontSize: var(--pf-global--FontSize--md);
-  margin-top: var(--pf-global--spacer--xs);
+  --pf-v5-c-table--cell--FontSize: var(--pf-v5-global--FontSize--md);
+  margin-top: var(--pf-v5-global--spacer--xs);
 }
 
 .co-logs-table__row::before {
@@ -25,7 +25,7 @@
   bottom: 3px;
   width: 3px;
   left: 3px;
-  background-color: var(--pf-global--disabled-color--200);
+  background-color: var(--pf-v5-global--disabled-color--200);
 }
 
 .co-logs-table__row-child-expanded::before {
@@ -37,54 +37,54 @@
 }
 
 .co-logs-table__severity-critical::before {
-  background-color: var(--pf-global--palette--purple-500);
+  background-color: var(--pf-v5-global--palette--purple-500);
 }
 
 .co-logs-table__severity-error::before {
-  background-color: var(--pf-global--danger-color--100);
+  background-color: var(--pf-v5-global--danger-color--100);
 }
 
 .co-logs-table__severity-warning::before {
-  background-color: var(--pf-global--warning-color--100);
+  background-color: var(--pf-v5-global--warning-color--100);
 }
 
 .co-logs-table__severity-info::before {
-  background-color: var(--pf-global--palette--green-300);
+  background-color: var(--pf-v5-global--palette--green-300);
 }
 
 .co-logs-table__severity-debug::before {
-  background-color: var(--pf-global--palette--light-blue-400);
+  background-color: var(--pf-v5-global--palette--light-blue-400);
 }
 
 .co-logs-table__severity-trace::before {
-  background-color: var(--pf-global--palette--cyan-200);
+  background-color: var(--pf-v5-global--palette--cyan-200);
 }
 
-.co-logs-table.pf-m-compact tr:not(.pf-c-table__expandable-row) > *:first-child {
+.co-logs-table.pf-m-compact tr:not(.pf-v5-c-table__expandable-row) > *:first-child {
   padding-left: 0;
 }
 
 .co-logs-table tr > :first-child::after {
-  --pf-c-table__expandable-row--after--BorderLeftWidth: none;
+  --pf-v5-c-table__expandable-row--after--BorderLeftWidth: none;
 }
 
 .co-logs-table__row-info {
-  font-size: var(--pf-global--FontSize--xs);
-  background-color: var(--pf-global--Background-color--100);
-  --pf-c-table--cell--PaddingBottom: var(--pf-global--spacer--xs);
-  --pf-c-table--cell--PaddingTop: var(--pf-global--spacer--xs);
+  font-size: var(--pf-v5-global--FontSize--xs);
+  background-color: var(--pf-v5-global--Background-color--100);
+  --pf-v5-c-table--cell--PaddingBottom: var(--pf-v5-global--spacer--xs);
+  --pf-v5-c-table--cell--PaddingTop: var(--pf-v5-global--spacer--xs);
 }
 
 .co-logs-table__row-info td {
   text-align: center;
 }
 
-.co-logs-table__row-info .pf-c-alert {
+.co-logs-table__row-info .pf-v5-c-alert {
   text-align: center;
-  --pf-c-alert__icon--FontSize: 0.9rem;
+  --pf-v5-c-alert__icon--FontSize: 0.9rem;
 }
 
-.co-logs-table__row-info .pf-c-alert__title {
+.co-logs-table__row-info .pf-v5-c-alert__title {
   font-size: 0.8rem;
 }
 

--- a/web/src/components/logs-table.css
+++ b/web/src/components/logs-table.css
@@ -60,7 +60,7 @@
   background-color: var(--pf-v5-global--palette--cyan-200);
 }
 
-.co-logs-table.pf-m-compact tr:not(.pf-v5-c-table__expandable-row) > *:first-child {
+.co-logs-table.pf-m-compact tr:not(.pf-v6-c-table__expandable-row) > *:first-child {
   padding-left: 0;
 }
 
@@ -79,12 +79,12 @@
   text-align: center;
 }
 
-.co-logs-table__row-info .pf-v5-c-alert {
+.co-logs-table__row-info .pf-v6-c-alert {
   text-align: center;
   --pf-v5-c-alert__icon--FontSize: 0.9rem;
 }
 
-.co-logs-table__row-info .pf-v5-c-alert__title {
+.co-logs-table__row-info .pf-v6-c-alert__title {
   font-size: 0.8rem;
 }
 

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -3,7 +3,7 @@ import { Alert, Split, SplitItem } from '@patternfly/react-core';
 import {
   ExpandableRowContent,
   ISortBy,
-  TableComposable,
+  Table /* data-codemods */,
   Tbody,
   Td,
   Th,
@@ -318,7 +318,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({
     <div data-test={TestIds.LogsTable}>
       {showStats && <StatsTable logsData={logsData} />}
       {children}
-      <TableComposable
+      <Table
         aria-label="Logs Table"
         variant="compact"
         className="co-logs-table"
@@ -453,7 +453,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({
             </Tr>
           </Tbody>
         )}
-      </TableComposable>
+      </Table>
     </div>
   );
 };

--- a/web/src/components/logs-toolbar.css
+++ b/web/src/components/logs-toolbar.css
@@ -1,5 +1,5 @@
 .co-logs-toolbar {
-  gap: var(--pf-global--spacer--md);
+  gap: var(--pf-v5-global--spacer--md);
 }
 
 .co-logs-severity-filter {
@@ -7,6 +7,6 @@
 }
 
 .co-logs-toolbar .co-logs-expression-input {
-  padding-right: var(--pf-c-toolbar__content--PaddingRight);
-  padding-left: var(--pf-c-toolbar__content--PaddingLeft);
+  padding-right: var(--pf-v5-c-toolbar__content--PaddingRight);
+  padding-left: var(--pf-v5-c-toolbar__content--PaddingLeft);
 }

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -1,9 +1,11 @@
 import {
   Alert,
+  Badge,
+  MenuToggle,
+  MenuToggleElement,
   Select,
+  SelectList,
   SelectOption,
-  SelectOptionObject,
-  SelectVariant,
   Toolbar,
   ToolbarChip,
   ToolbarChipGroup,
@@ -112,10 +114,10 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   };
 
   const onSeveritySelect = (
-    _: React.MouseEvent | React.ChangeEvent,
-    value: string | SelectOptionObject,
+    _: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
   ) => {
-    const severityValue = value.toString() as Severity;
+    const severityValue = String(value ?? 'unknown') as Severity;
 
     if (severityFilter.has(severityValue)) {
       severityFilter.delete(severityValue);
@@ -128,6 +130,23 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       severity: new Set(severityFilter),
     });
   };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onSeverityToggle}
+      isExpanded={isSeverityExpanded}
+      isDisabled={isDisabled}
+      style={
+        {
+          width: '200px',
+        } as React.CSSProperties
+      }
+    >
+      Filter by status
+      {severityFilter.size > 0 && <Badge isRead>{severityFilter.size}</Badge>}
+    </MenuToggle>
+  );
 
   const severityFilterArray = Array.from(severityFilter);
 
@@ -151,18 +170,23 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             data-test={TestIds.SeverityDropdown}
           >
             <Select
-              variant={SelectVariant.checkbox}
+              role="menu"
               aria-label="Severity"
-              onToggle={onSeverityToggle}
               onSelect={onSeveritySelect}
-              selections={severityFilterArray}
               isOpen={isSeverityExpanded}
-              placeholderText="Severity"
-              isDisabled={isDisabled}
+              placeholder="Severity"
+              toggle={toggle}
             >
-              {availableSeverityFilters.map((severity) => (
-                <SelectOption key={severity} value={severity} />
-              ))}
+              <SelectList>
+                {availableSeverityFilters.map((severity) => (
+                  <SelectOption
+                    key={severity}
+                    value={severity}
+                    hasCheckbox
+                    isSelected={severityFilter.has(severity)}
+                  />
+                ))}
+              </SelectList>
             </Select>
           </ToolbarFilter>
         </ToolbarGroup>

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -7,8 +7,8 @@ import {
   SelectList,
   SelectOption,
   Toolbar,
-  ToolbarChip,
-  ToolbarChipGroup,
+  ToolbarLabel,
+  ToolbarLabelGroup,
   ToolbarContent,
   ToolbarFilter,
   ToolbarGroup,
@@ -93,8 +93,8 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
     : new Set();
 
   const onDeleteSeverityFilter = (
-    _category: string | ToolbarChipGroup,
-    chip: string | ToolbarChip,
+    _category: string | ToolbarLabelGroup,
+    chip: string | ToolbarLabel,
   ) => {
     severityFilter.delete(chip.toString() as Severity);
     const newFilters = { ...(filters ?? {}), severity: severityFilter };
@@ -162,9 +162,9 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
         )}
         <ToolbarGroup>
           <ToolbarFilter
-            chips={severityFilterArray}
-            deleteChip={onDeleteSeverityFilter}
-            deleteChipGroup={onDeleteSeverityGroup}
+            labels={severityFilterArray}
+            deleteLabel={onDeleteSeverityFilter}
+            deleteLabelGroup={onDeleteSeverityGroup}
             categoryName="Severity"
             className="co-logs-severity-filter"
             data-test={TestIds.SeverityDropdown}

--- a/web/src/components/precision-time-picker.css
+++ b/web/src/components/precision-time-picker.css
@@ -8,5 +8,5 @@
 }
 
 .co-logs-time-picker__error {
-  padding-top: 'var(--pf-global--spacer--xs)';
+  padding-top: 'var(--pf-v5-global--spacer--xs)';
 }

--- a/web/src/components/precision-time-picker.tsx
+++ b/web/src/components/precision-time-picker.tsx
@@ -126,8 +126,7 @@ export const PrecisionTimePicker: React.FC<PrecisionTimePickerProps> = ({ onChan
         value={value}
         onFocus={openMenu}
         type="text"
-        iconVariant="clock"
-        onChange={handleValueChange}
+        onChange={(_event, changedValue: string) => handleValueChange(changedValue)}
         aria-label="Precision time picker"
         isRequired
         validated={isValid ? undefined : ValidatedOptions.error}

--- a/web/src/components/refresh-interval-dropdown.tsx
+++ b/web/src/components/refresh-interval-dropdown.tsx
@@ -1,4 +1,11 @@
-import { Dropdown, DropdownItem, DropdownToggle, FormGroup } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocalStorage } from '../hooks/useLocalStorage';
@@ -81,33 +88,42 @@ export const RefreshIntervalDropdown: React.FC<RefreshIntervalDropdownProps> = (
   return (
     <FormGroup fieldId="logs-refresh-interval" data-test={TestIds.RefreshIntervalDropdown}>
       <Dropdown
-        disabled={isDisabled}
-        dropdownItems={refreshIntervalOptions.map(({ key, name }, index) => (
-          <DropdownItem componentID={key} onClick={handleSelectedValue(index)} key={key}>
-            {
-              /*
-                t('plugin__logging-view-plugin~Refresh off')
-                t('plugin__logging-view-plugin~15 seconds')
-                t('plugin__logging-view-plugin~30 seconds')
-                t('plugin__logging-view-plugin~1 minute')
-                t('plugin__logging-view-plugin~5 minutes')
-                t('plugin__logging-view-plugin~15 minutes')
-                t('plugin__logging-view-plugin~30 minutes')
-                t('plugin__logging-view-plugin~1 hour')
-                t('plugin__logging-view-plugin~2 hours')
-                t('plugin__logging-view-plugin~1 day')
-              */
-              t(name)
-            }
-          </DropdownItem>
-        ))}
         isOpen={isOpen}
-        toggle={
-          <DropdownToggle isDisabled={isDisabled} onToggle={toggleIsOpen}>
+        onSelect={() => setIsOpen(false)}
+        onOpenChange={(isOpenVal: boolean) => setIsOpen(isOpenVal)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            isDisabled={isDisabled}
+            ref={toggleRef}
+            onClick={toggleIsOpen}
+            isExpanded={isOpen}
+          >
             {refreshIntervalOptions[selectedIndex].name}
-          </DropdownToggle>
-        }
-      />
+          </MenuToggle>
+        )}
+      >
+        <DropdownList>
+          {refreshIntervalOptions.map(({ key, name }, index) => (
+            <DropdownItem ouiaId={key} onClick={handleSelectedValue(index)} key={key}>
+              {
+                /*
+                  t('plugin__logging-view-plugin~Refresh off')
+                  t('plugin__logging-view-plugin~15 seconds')
+                  t('plugin__logging-view-plugin~30 seconds')
+                  t('plugin__logging-view-plugin~1 minute')
+                  t('plugin__logging-view-plugin~5 minutes')
+                  t('plugin__logging-view-plugin~15 minutes')
+                  t('plugin__logging-view-plugin~30 minutes')
+                  t('plugin__logging-view-plugin~1 hour')
+                  t('plugin__logging-view-plugin~2 hours')
+                  t('plugin__logging-view-plugin~1 day')
+                */
+                t(name)
+              }
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      </Dropdown>
     </FormGroup>
   );
 };

--- a/web/src/components/stats-table.tsx
+++ b/web/src/components/stats-table.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { QueryRangeResponse } from '../logs.types';
 import { Tooltip } from '@patternfly/react-core';
-import { Tbody, Table, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { TestIds } from '../test-ids';
 import { useTranslation } from 'react-i18next';
 import './stats-table.css';
@@ -87,7 +87,10 @@ export const StatsTable: React.FC<StatsTableProps> = ({ logsData }) => {
             </Tr>
 
             <Tr>
-              <Tooltip content={t('Total of bytes processed per second')} className="pf-c-tooltip">
+              <Tooltip
+                content={t('Total of bytes processed per second')}
+                className="pf-v5-c-tooltip"
+              >
                 <Td>Bytes Processed Per Second:</Td>
               </Tooltip>
               <Td>

--- a/web/src/components/stats-table.tsx
+++ b/web/src/components/stats-table.tsx
@@ -89,7 +89,7 @@ export const StatsTable: React.FC<StatsTableProps> = ({ logsData }) => {
             <Tr>
               <Tooltip
                 content={t('Total of bytes processed per second')}
-                className="pf-v5-c-tooltip"
+                className="pf-v6-c-tooltip"
               >
                 <Td>Bytes Processed Per Second:</Td>
               </Tooltip>

--- a/web/src/components/tenant-dropdown.tsx
+++ b/web/src/components/tenant-dropdown.tsx
@@ -1,8 +1,14 @@
-import { OptionsMenu, OptionsMenuItem, OptionsMenuToggle } from '@patternfly/react-core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TENANTS } from '../tenants';
 import { TestIds } from '../test-ids';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 
 interface TenantDropdownProps {
   selectedTenant?: string;
@@ -29,28 +35,31 @@ export const TenantDropdown: React.FC<TenantDropdownProps> = ({
   };
 
   return (
-    <OptionsMenu
+    <Dropdown
       id="logging-view-tenant-dropdown"
       data-test={TestIds.TenantDropdown}
-      disabled={isDisabled}
-      menuItems={TENANTS.map((tenant) => (
-        <OptionsMenuItem
-          onSelect={onSelect}
-          isSelected={selectedTenant === tenant}
-          key={tenant}
-          id={tenant}
-        >
-          {tenant}
-        </OptionsMenuItem>
-      ))}
       isOpen={isOpen}
-      toggle={
-        <OptionsMenuToggle
-          isDisabled={isDisabled}
-          onToggle={onToggle}
-          toggleTemplate={selectedTenant ?? t('Select a tenant')}
-        />
-      }
-    />
+      onSelect={() => setIsOpen(false)}
+      onOpenChange={(isOpenVal: boolean) => setIsOpen(isOpenVal)}
+      placeholder={t('Select a tenant')}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle isDisabled={isDisabled} ref={toggleRef} onClick={onToggle} isExpanded={isOpen}>
+          {selectedTenant}
+        </MenuToggle>
+      )}
+    >
+      <DropdownList>
+        {TENANTS.map((tenant) => (
+          <DropdownItem
+            ouiaId={tenant}
+            onClick={onSelect}
+            key={tenant}
+            isSelected={selectedTenant === tenant}
+          >
+            {tenant}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
   );
 };

--- a/web/src/components/time-range-dropdown.tsx
+++ b/web/src/components/time-range-dropdown.tsx
@@ -1,4 +1,11 @@
-import { Dropdown, DropdownItem, DropdownToggle, FormGroup } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import React from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { TimeRange } from '../logs.types';
@@ -108,37 +115,46 @@ export const TimeRangeDropdown: React.FC<TimeRangeDropdownProps> = ({
       )}
       <FormGroup fieldId="logs-time-range" data-test={TestIds.TimeRangeDropdown}>
         <Dropdown
-          disabled={isDisabled}
-          dropdownItems={timeRangeOptions.map(({ key, name }, index) => (
-            <DropdownItem componentID={key} onClick={handleSelectedValue(index)} key={key}>
-              {
-                /*
-                  t('plugin__logging-view-plugin~Custom time range')
-                  t('plugin__logging-view-plugin~Last 5 minutes')
-                  t('plugin__logging-view-plugin~Last 15 minutes')
-                  t('plugin__logging-view-plugin~Last 30 minutes')
-                  t('plugin__logging-view-plugin~Last 1 hour')
-                  t('plugin__logging-view-plugin~Last 2 hours')
-                  t('plugin__logging-view-plugin~Last 6 hours')
-                  t('plugin__logging-view-plugin~Last 12 hours')
-                  t('plugin__logging-view-plugin~Last 1 day')
-                  t('plugin__logging-view-plugin~Last 2 days')
-                  t('plugin__logging-view-plugin~Last 1 week')
-                  t('plugin__logging-view-plugin~Last 2 weeks')
-                */
-                t(`plugin__logging-view-plugin~${name}`)
-              }
-            </DropdownItem>
-          ))}
           isOpen={isOpen}
-          toggle={
-            <DropdownToggle isDisabled={isDisabled} onToggle={toggleIsOpen}>
+          onSelect={() => setIsOpen(false)}
+          onOpenChange={(isOpenVal: boolean) => setIsOpen(isOpenVal)}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              isDisabled={isDisabled}
+              ref={toggleRef}
+              onClick={toggleIsOpen}
+              isExpanded={isOpen}
+            >
               {timeRangeOptions[selectedIndex].key === CUSTOM_TIME_RANGE_KEY && timeRangeValue
                 ? formatTimeRange(timeRangeValue)
                 : timeRangeOptions[selectedIndex].name}
-            </DropdownToggle>
-          }
-        />
+            </MenuToggle>
+          )}
+        >
+          <DropdownList>
+            {timeRangeOptions.map(({ key, name }, index) => (
+              <DropdownItem ouiaId={key} onClick={handleSelectedValue(index)} key={key}>
+                {
+                  /*
+                    t('plugin__logging-view-plugin~Custom time range')
+                    t('plugin__logging-view-plugin~Last 5 minutes')
+                    t('plugin__logging-view-plugin~Last 15 minutes')
+                    t('plugin__logging-view-plugin~Last 30 minutes')
+                    t('plugin__logging-view-plugin~Last 1 hour')
+                    t('plugin__logging-view-plugin~Last 2 hours')
+                    t('plugin__logging-view-plugin~Last 6 hours')
+                    t('plugin__logging-view-plugin~Last 12 hours')
+                    t('plugin__logging-view-plugin~Last 1 day')
+                    t('plugin__logging-view-plugin~Last 2 days')
+                    t('plugin__logging-view-plugin~Last 1 week')
+                    t('plugin__logging-view-plugin~Last 2 weeks')
+                  */
+                  t(`plugin__logging-view-plugin~${name}`)
+                }
+              </DropdownItem>
+            ))}
+          </DropdownList>
+        </Dropdown>
       </FormGroup>
     </>
   );

--- a/web/src/components/time-range-select-modal.css
+++ b/web/src/components/time-range-select-modal.css
@@ -1,10 +1,10 @@
 .co-logs-time-range-modal {
-  --pf-global--FontSize--md: 14px;
+  --pf-v5-global--FontSize--md: 14px;
 }
 
 .co-logs-time-range-modal__footer {
   display: flex;
-  gap: var(--pf-global--spacer--sm);
+  gap: var(--pf-v5-global--spacer--sm);
   justify-content: flex-end;
   width: 100%;
 }
@@ -12,7 +12,7 @@
 .co-logs-time-range-modal__body {
   overflow: visible;
   display: grid;
-  gap: var(--pf-global--spacer--md);
+  gap: var(--pf-v5-global--spacer--md);
 }
 
 .co-logs-time-range-modal__field {
@@ -21,5 +21,5 @@
 }
 
 .co-logs-time-range-modal__error {
-  margin-top: var(--pf-global--spacer--md);
+  margin-top: var(--pf-v5-global--spacer--md);
 }

--- a/web/src/components/time-range-select-modal.tsx
+++ b/web/src/components/time-range-select-modal.tsx
@@ -1,11 +1,5 @@
-import {
-  Alert,
-  Button,
-  DatePicker,
-  Modal,
-  ModalBoxBody,
-  ModalVariant,
-} from '@patternfly/react-core';
+import { Alert, Button, DatePicker } from '@patternfly/react-core';
+import { Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core/deprecated';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DateFormat, dateToFormat } from '../date-utils';

--- a/web/src/components/toggle-button.css
+++ b/web/src/components/toggle-button.css
@@ -1,4 +1,4 @@
 .co-logs-toggle-button {
-  padding-right: var(--pf-global--spacer--xs);
-  padding-left: var(--pf-global--spacer--xs);
+  padding-right: var(--pf-v5-global--spacer--xs);
+  padding-left: var(--pf-v5-global--spacer--xs);
 }

--- a/web/src/components/toggle-play.css
+++ b/web/src/components/toggle-play.css
@@ -1,4 +1,4 @@
-.co-logs-toggle-play.pf-v5-c-button {
+.co-logs-toggle-play.pf-v6-c-button {
   background-color: var(--pf-v5-global--BackgroundColor--100);
   border: var(--pf-v5-global--BorderWidth--lg) solid
     var(--pf-v5-global--BorderColor--100);
@@ -9,6 +9,6 @@
   cursor: pointer;
 }
 
-.co-logs-toggle-play.pf-v5-c-button.co-logs-toggle-play--active {
+.co-logs-toggle-play.pf-v6-c-button.co-logs-toggle-play--active {
   border-color: var(--pf-v5-global--palette--green-300);
 }

--- a/web/src/components/toggle-play.css
+++ b/web/src/components/toggle-play.css
@@ -1,7 +1,7 @@
-.co-logs-toggle-play.pf-c-button {
-  background-color: var(--pf-global--BackgroundColor--100);
-  border: var(--pf-global--BorderWidth--lg) solid
-    var(--pf-global--BorderColor--100);
+.co-logs-toggle-play.pf-v5-c-button {
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+  border: var(--pf-v5-global--BorderWidth--lg) solid
+    var(--pf-v5-global--BorderColor--100);
   border-radius: 50%;
   height: 32px;
   padding: 0;
@@ -9,6 +9,6 @@
   cursor: pointer;
 }
 
-.co-logs-toggle-play.pf-c-button.co-logs-toggle-play--active {
-  border-color: var(--pf-global--palette--green-300);
+.co-logs-toggle-play.pf-v5-c-button.co-logs-toggle-play--active {
+  border-color: var(--pf-v5-global--palette--green-300);
 }

--- a/web/src/components/toggle-play.tsx
+++ b/web/src/components/toggle-play.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@patternfly/react-core';
+import { Button, Icon } from '@patternfly/react-core';
 import { PauseIcon, PlayIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +23,15 @@ export const TogglePlay: React.FC<TogglePlayProps> = ({ onClick, active, isDisab
       isDisabled={isDisabled}
       data-test={TestIds.ToogleStreamingButton}
     >
-      {active ? <PauseIcon size="sm" /> : <PlayIcon size="sm" />}
+      {active ? (
+        <Icon size="sm">
+          <PauseIcon />
+        </Icon>
+      ) : (
+        <Icon size="sm">
+          <PlayIcon />
+        </Icon>
+      )}
     </Button>
   );
 };

--- a/web/src/components/toggle-play.tsx
+++ b/web/src/components/toggle-play.tsx
@@ -16,22 +16,23 @@ export const TogglePlay: React.FC<TogglePlayProps> = ({ onClick, active, isDisab
 
   return (
     <Button
+      icon={
+        active ? (
+          <Icon size="sm">
+            <PauseIcon />
+          </Icon>
+        ) : (
+          <Icon size="sm">
+            <PlayIcon />
+          </Icon>
+        )
+      }
       variant="plain"
       className={`co-logs-toggle-play ${active ? 'co-logs-toggle-play--active' : ''}`}
       onClick={onClick}
       aria-label={active ? t('Pause streaming') : t('Start streaming')}
       isDisabled={isDisabled}
       data-test={TestIds.ToogleStreamingButton}
-    >
-      {active ? (
-        <Icon size="sm">
-          <PauseIcon />
-        </Icon>
-      ) : (
-        <Icon size="sm">
-          <PlayIcon />
-        </Icon>
-      )}
-    </Button>
+    />
   );
 };

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -1,5 +1,4 @@
 import '@patternfly/patternfly/patternfly.css';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter, Link, Route, useHistory, useParams } from 'react-router-dom';
@@ -9,6 +8,13 @@ import './index.css';
 import LogsDetailPage from './pages/logs-detail-page';
 import LogsDevPage from './pages/logs-dev-page';
 import LogsPage from './pages/logs-page';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 
 const DevConsole = () => {
   const { ns: namespace } = useParams<{ ns: string }>();
@@ -28,39 +34,42 @@ const DevConsole = () => {
     <>
       <Dropdown
         data-test="namespace-dropdown"
-        toggle={
-          <DropdownToggle id="toggle-basic" onToggle={onToggle} data-test="namespace-toggle">
-            {namespace}
-          </DropdownToggle>
-        }
         isOpen={isOpen}
-        dropdownItems={[
+        onSelect={() => setIsOpen(false)}
+        onOpenChange={(isOpenVal: boolean) => setIsOpen(isOpenVal)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen} id="toggle-basic">
+            {namespace}
+          </MenuToggle>
+        )}
+      >
+        <DropdownList>
           <DropdownItem onClick={onSelectNamespace('default')} key="default" component="button">
             default
-          </DropdownItem>,
+          </DropdownItem>
           <DropdownItem
             onClick={onSelectNamespace('my-namespace')}
             key="my-namespace"
             component="button"
           >
             my-namespace
-          </DropdownItem>,
+          </DropdownItem>
           <DropdownItem
             onClick={onSelectNamespace('my-namespace-two')}
             key="my-namespace-two"
             component="button"
           >
             my-namespace-two
-          </DropdownItem>,
+          </DropdownItem>
           <DropdownItem
             onClick={onSelectNamespace('openshift-cluster-version')}
             key="action"
             component="button"
           >
             openshift-cluster-version
-          </DropdownItem>,
-        ]}
-      />
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
       <LogsDevPage />
     </>
   );
@@ -68,33 +77,33 @@ const DevConsole = () => {
 
 const EndToEndTestsApp = () => {
   return (
-    <div className="pf-c-page co-logs-standalone__page">
+    <div className="pf-v5-c-page co-logs-standalone__page">
       <BrowserRouter>
-        <header className="pf-c-masthead">
-          <div className="pf-c-masthead__main"></div>
+        <header className="pf-v5-c-masthead">
+          <div className="pf-v5-c-masthead__main"></div>
         </header>
 
-        <div className="pf-c-page__sidebar co-logs-standalone__side-menu">
-          <div className="pf-c-page__sidebar-body">
-            <nav className="pf-c-nav" aria-label="Global">
-              <ul className="pf-c-nav__list">
-                <li className="pf-c-nav__item">
-                  <Link className="pf-c-nav__link" to="/k8s/ns/default/pods/test-pod-name">
+        <div className="pf-v5-c-page__sidebar co-logs-standalone__side-menu">
+          <div className="pf-v5-c-page__sidebar-body">
+            <nav className="pf-v5-c-nav" aria-label="Global">
+              <ul className="pf-v5-c-nav__list">
+                <li className="pf-v5-c-nav__item">
+                  <Link className="pf-v5-c-nav__link" to="/k8s/ns/default/pods/test-pod-name">
                     Pods Logs
                   </Link>
                 </li>
-                <li className="pf-c-nav__item">
-                  <Link className="pf-c-nav__link" to="/dev-monitoring/ns/my-namespace/logs">
+                <li className="pf-v5-c-nav__item">
+                  <Link className="pf-v5-c-nav__link" to="/dev-monitoring/ns/my-namespace/logs">
                     Dev Logs
                   </Link>
                 </li>
-                <li className="pf-c-nav__item">
-                  <Link className="pf-c-nav__link" to="/monitoring/logs">
+                <li className="pf-v5-c-nav__item">
+                  <Link className="pf-v5-c-nav__link" to="/monitoring/logs">
                     Logs
                   </Link>
                 </li>
-                <li className="pf-c-nav__item">
-                  <Link className="pf-c-nav__link" to="/monitoring/alerts/test-alert">
+                <li className="pf-v5-c-nav__item">
+                  <Link className="pf-v5-c-nav__link" to="/monitoring/alerts/test-alert">
                     Alerts
                   </Link>
                 </li>
@@ -103,7 +112,7 @@ const EndToEndTestsApp = () => {
           </div>
         </div>
 
-        <main className="pf-c-page__main" tabIndex={-1}>
+        <main className="pf-v5-c-page__main" tabIndex={-1}>
           <Route path="/monitoring/logs">
             <LogsPage />
           </Route>

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -77,33 +77,33 @@ const DevConsole = () => {
 
 const EndToEndTestsApp = () => {
   return (
-    <div className="pf-v5-c-page co-logs-standalone__page">
+    <div className="pf-v6-c-page co-logs-standalone__page">
       <BrowserRouter>
-        <header className="pf-v5-c-masthead">
-          <div className="pf-v5-c-masthead__main"></div>
+        <header className="pf-v6-c-masthead">
+          <div className="pf-v6-c-masthead__main"></div>
         </header>
 
-        <div className="pf-v5-c-page__sidebar co-logs-standalone__side-menu">
-          <div className="pf-v5-c-page__sidebar-body">
-            <nav className="pf-v5-c-nav" aria-label="Global">
-              <ul className="pf-v5-c-nav__list">
-                <li className="pf-v5-c-nav__item">
-                  <Link className="pf-v5-c-nav__link" to="/k8s/ns/default/pods/test-pod-name">
+        <div className="pf-v6-c-page__sidebar co-logs-standalone__side-menu">
+          <div className="pf-v6-c-page__sidebar-body">
+            <nav className="pf-v6-c-nav" aria-label="Global">
+              <ul className="pf-v6-c-nav__list">
+                <li className="pf-v6-c-nav__item">
+                  <Link className="pf-v6-c-nav__link" to="/k8s/ns/default/pods/test-pod-name">
                     Pods Logs
                   </Link>
                 </li>
-                <li className="pf-v5-c-nav__item">
-                  <Link className="pf-v5-c-nav__link" to="/dev-monitoring/ns/my-namespace/logs">
+                <li className="pf-v6-c-nav__item">
+                  <Link className="pf-v6-c-nav__link" to="/dev-monitoring/ns/my-namespace/logs">
                     Dev Logs
                   </Link>
                 </li>
-                <li className="pf-v5-c-nav__item">
-                  <Link className="pf-v5-c-nav__link" to="/monitoring/logs">
+                <li className="pf-v6-c-nav__item">
+                  <Link className="pf-v6-c-nav__link" to="/monitoring/logs">
                     Logs
                   </Link>
                 </li>
-                <li className="pf-v5-c-nav__item">
-                  <Link className="pf-v5-c-nav__link" to="/monitoring/alerts/test-alert">
+                <li className="pf-v6-c-nav__item">
+                  <Link className="pf-v6-c-nav__link" to="/monitoring/alerts/test-alert">
                     Alerts
                   </Link>
                 </li>
@@ -112,7 +112,7 @@ const EndToEndTestsApp = () => {
           </div>
         </div>
 
-        <main className="pf-v5-c-page__main" tabIndex={-1}>
+        <main className="pf-v6-c-page__main" tabIndex={-1}>
           <Route path="/monitoring/logs">
             <LogsPage />
           </Route>

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -168,7 +168,7 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
   }, [resultIsMetric]);
 
   return (
-    <PageSection>
+    <PageSection hasBodyWrapper={false}>
       <Grid hasGutter>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
           <Title headingLevel="h1" size="lg">
@@ -189,13 +189,12 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
             <RefreshIntervalDropdown onRefresh={runQuery} isDisabled={isQueryEmpty} />
             <Tooltip content={<div>Refresh</div>}>
               <Button
+                icon={<SyncAltIcon />}
                 onClick={runQuery}
                 aria-label="Refresh"
                 variant="secondary"
                 data-test={TestIds.SyncButton}
-              >
-                <SyncAltIcon />
-              </Button>
+              ></Button>
             </Tooltip>
           </Flex>
         </Flex>

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -200,7 +200,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
   }, [resultIsMetric]);
 
   return (
-    <PageSection>
+    <PageSection hasBodyWrapper={false}>
       <Grid hasGutter>
         <Flex justifyContent={{ default: 'justifyContentFlexEnd' }}>
           <Flex>
@@ -218,14 +218,13 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
             <RefreshIntervalDropdown onRefresh={runQuery} isDisabled={isRunQueryDisabled} />
             <Tooltip content={<div>Refresh</div>}>
               <Button
+                icon={<SyncAltIcon />}
                 onClick={handleRefreshClick}
                 aria-label="Refresh"
                 variant="secondary"
                 data-test={TestIds.SyncButton}
                 isDisabled={isRunQueryDisabled}
-              >
-                <SyncAltIcon />
-              </Button>
+              ></Button>
             </Tooltip>
           </Flex>
         </Flex>

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -164,7 +164,7 @@ const LogsPage: React.FC = () => {
   }, [resultIsMetric]);
 
   return (
-    <PageSection>
+    <PageSection hasBodyWrapper={false}>
       <Grid hasGutter>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
           <Title headingLevel="h1" size="lg">
@@ -185,14 +185,13 @@ const LogsPage: React.FC = () => {
             <RefreshIntervalDropdown onRefresh={runQuery} isDisabled={isQueryEmpty} />
             <Tooltip content={<div>Refresh</div>}>
               <Button
+                icon={<SyncAltIcon />}
                 onClick={handleRefreshClick}
                 aria-label="Refresh"
                 variant="secondary"
                 data-test={TestIds.SyncButton}
                 isDisabled={isQueryEmpty}
-              >
-                <SyncAltIcon />
-              </Button>
+              ></Button>
             </Tooltip>
           </Flex>
         </Flex>

--- a/web/src/severity.ts
+++ b/web/src/severity.ts
@@ -1,10 +1,10 @@
 import chartGrayColor from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chartBlueColor from '@patternfly/react-tokens/dist/esm/chart_color_blue_200';
-import chartCyanColor from '@patternfly/react-tokens/dist/esm/chart_color_cyan_200';
-import chartYellowColor from '@patternfly/react-tokens/dist/esm/chart_color_gold_200';
+import chartTealColor from '@patternfly/react-tokens/dist/esm/chart_color_teal_200';
+import chartYellowColor from '@patternfly/react-tokens/dist/esm/chart_color_yellow_200';
 import chartGreenColor from '@patternfly/react-tokens/dist/esm/chart_color_green_200';
 import chartPurpleColor from '@patternfly/react-tokens/dist/esm/chart_color_purple_200';
-import chartRedColor from '@patternfly/react-tokens/dist/esm/chart_color_red_100';
+import chartRedColor from '@patternfly/react-tokens/dist/esm/chart_color_red_orange_100';
 
 export type Severity =
   | 'critical'
@@ -60,7 +60,7 @@ export const getSeverityColor = (severity: Severity): string => {
       return chartBlueColor.value;
       break;
     case 'trace':
-      return chartCyanColor.value;
+      return chartTealColor.value;
       break;
     default:
       return chartGrayColor.value;


### PR DESCRIPTION
Awaiting openshift/console#14621 to finish. Currently the plugin is unable to be loaded due to @patternfly/react-core not being found in the shared modules.

No typescript, compilation, linting or test errors.

This is a 2 version upgrade so there needs to be extensive manual and preferably more automated testing completed once the console and the SDK are using PF6. 

Known regression in search-select.tsx where it is not able to create new items. 

Codegen for the PF5 => PF6 didn't upgrade many of the PF5 css variables in css or scss files. Instead the suggestion of the upgrade is to look to remove as many overrides of CSS as possible to make upgrades easier in the future. We will need to decide how we want to handle that part of the upgrade, either by following the suggestion or updating the CSS ourselves, but the theming will be different in PF6 so there will need to be additional changes regardless