### PR TITLE
OU-660: rename co- classes to lv-plugin

### DIFF
--- a/web/cypress/integration/logs-page.cy.ts
+++ b/web/cypress/integration/logs-page.cy.ts
@@ -532,7 +532,7 @@ describe('Logs Page', () => {
     cy.getByTestId(TestIds.LogsTable)
       .should('exist')
       .within(() => {
-        cy.get('.co-logs-table__message').first().contains('formatted string');
+        cy.get('.lv-plugin__table__message').first().contains('formatted string');
       });
 
     cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);
@@ -550,7 +550,7 @@ describe('Logs Page', () => {
     cy.getByTestId(TestIds.LogsTable)
       .should('exist')
       .within(() => {
-        cy.get('.co-logs-table__message').first().contains('a message');
+        cy.get('.lv-plugin__table__message').first().contains('a message');
       });
 
     cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);

--- a/web/src/components/alerts/logs-alerts-metrics.css
+++ b/web/src/components/alerts/logs-alerts-metrics.css
@@ -1,13 +1,13 @@
-.co-logs-alert-metrics__container {
+.lv-plugin__alert-metrics__container {
   border: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
   margin: 0 0 var(--pf-v5-global--spacer--md) 0;
   padding: var(--pf-v5-global--spacer--sm);
 }
 
-.co-logs-metrics__header {
+.lv-plugin__metrics__header {
   margin-bottom: var(--pf-v5-global--spacer--sm);
 }
 
-.co-logs-metrics__error {
+.lv-plugin__metrics__error {
   min-height: 250px;
 }

--- a/web/src/components/alerts/logs-alerts-metrics.tsx
+++ b/web/src/components/alerts/logs-alerts-metrics.tsx
@@ -33,8 +33,8 @@ const LogsAlertMetrics: React.FC<LogsAlertMetricsProps> = ({ rule }) => {
     : undefined;
 
   return (
-    <div className="co-logs-alert-metrics__container">
-      <div className="co-logs-metrics__header">
+    <div className="lv-plugin__alert-metrics__container">
+      <div className="lv-plugin__metrics__header">
         <TimeRangeDropdown value={timeRange} onChange={setTimeRange} />
       </div>
       <LogsMetrics

--- a/web/src/components/error-message.css
+++ b/web/src/components/error-message.css
@@ -1,9 +1,9 @@
-.co-logs-error_message {
+.lv-plugin__error_message {
   margin-bottom: var(--pf-v5-global--spacer--md);
   margin-top: var(--pf-v5-global--spacer--md);
   background-color: transparent;
 }
 
-.co-logs-table__row-error .pf-v5-c-code-block__pre {
+.lv-plugin__table__row-error .pf-v5-c-code-block__pre {
   text-align: left;
 }

--- a/web/src/components/error-message.tsx
+++ b/web/src/components/error-message.tsx
@@ -130,7 +130,7 @@ export const ErrorMessage: React.FC<ErrorMessageProps> = ({ error }) => {
   return (
     <>
       <Alert
-        className="co-logs-error_message"
+        className="lv-plugin__error_message"
         variant="danger"
         isInline
         isPlain

--- a/web/src/components/filters/attribute-filter.css
+++ b/web/src/components/filters/attribute-filter.css
@@ -1,7 +1,7 @@
-.co-logs__attribute-filter .pf-v5-c-select__toggle-wrapper {
+.lv-plugin__attribute-filter .pf-v5-c-select__toggle-wrapper {
   flex-wrap: nowrap;
 }
 
-.co-logs__attribute-filter .co-logs__attribute-filter__text {
+.lv-plugin__attribute-filter .lv-plugin__attribute-filter__text {
   min-width: 200px;
 }

--- a/web/src/components/filters/attribute-filter.tsx
+++ b/web/src/components/filters/attribute-filter.tsx
@@ -149,7 +149,7 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
               attributeName: attribute.name,
             })}
             onChange={(_event, value: string) => handleInputValueChange(value)}
-            className="co-logs__attribute-filter__text"
+            className="lv-plugin__attribute-filter__text"
             aria-label={t('Search by {{attributeName}}', {
               attributeName: attribute.name,
             })}
@@ -183,7 +183,7 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
     <>
       <ToolbarGroup
         variant="filter-group"
-        className="co-logs__attribute-filter"
+        className="lv-plugin__attribute-filter"
         data-test={TestIds.AttributeFilters}
       >
         <Select

--- a/web/src/components/filters/search-select.css
+++ b/web/src/components/filters/search-select.css
@@ -1,4 +1,4 @@
-.co-logs__search-select .pf-v5-c-form__fieldset {
+.lv-plugin__search-select .pf-v5-c-form__fieldset {
   max-height: 50vh;
   overflow: auto;
 }

--- a/web/src/components/filters/search-select.tsx
+++ b/web/src/components/filters/search-select.tsx
@@ -317,7 +317,7 @@ export const SearchSelect: React.FC<SearchSelectProps> = ({
         })}
         aria-labelledby={titleId}
         aria-placeholder={t('Search')}
-        className="co-logs__search-select"
+        className="lv-plugin__search-select"
         toggle={toggle}
       >
         <SelectList isAriaMultiselectable>

--- a/web/src/components/log-detail.css
+++ b/web/src/components/log-detail.css
@@ -1,11 +1,11 @@
-.pf-v5-c-description-list.pf-v5-m-compact.co-logs-detail_descripton-list {
+.pf-v5-c-description-list.pf-v5-m-compact.lv-plugin__detail_descripton-list {
   --pf-v5-c-description-list--RowGap: var(--pf-v5-global--spacer--sm);
 }
 
-.co-logs-detail__list-term {
+.lv-plugin__detail__list-term {
   overflow-wrap: anywhere;
 }
 
-.co-logs-detail_descripton-list .pf-v5-c-description-list__group {
+.lv-plugin__detail_descripton-list .pf-v5-c-description-list__group {
   grid-template-columns: max-content 1fr;
 }

--- a/web/src/components/log-detail.tsx
+++ b/web/src/components/log-detail.tsx
@@ -19,14 +19,14 @@ export const LogDetail: React.FC<LogDetailProps> = ({ data }) => (
     columnModifier={{
       default: '2Col',
     }}
-    className="co-logs-detail_descripton-list"
+    className="lv-plugin__detail_descripton-list"
   >
     {Object.keys(data)
       .filter((key) => key !== '_')
       .sort()
       .map((key) => (
         <DescriptionListGroup key={key}>
-          <DescriptionListTerm className="co-logs-detail__list-term">{key}</DescriptionListTerm>
+          <DescriptionListTerm className="lv-plugin__detail__list-term">{key}</DescriptionListTerm>
           <DescriptionListDescription>{data[key]}</DescriptionListDescription>
         </DescriptionListGroup>
       ))}

--- a/web/src/components/logs-histogram.css
+++ b/web/src/components/logs-histogram.css
@@ -1,4 +1,4 @@
-.co-logs-histogram__tooltip-line{
+.lv-plugin__histogram__tooltip-line {
   stroke: var(--pf-v5-global--BackgroundColor--dark-100);
   stroke-dasharray: 3;
 }

--- a/web/src/components/logs-histogram.tsx
+++ b/web/src/components/logs-histogram.tsx
@@ -176,7 +176,7 @@ const HistogramTooltip: React.FC<ChartLegendTooltipProps & { interval: number }>
         constrainToVisibleArea
       />
       <line
-        className="co-logs-histogram__tooltip-line"
+        className="lv-plugin__histogram__tooltip-line"
         x1={xCoord}
         x2={xCoord}
         y1={TOP_PADDING}

--- a/web/src/components/logs-metrics.css
+++ b/web/src/components/logs-metrics.css
@@ -1,4 +1,4 @@
-.co-logs-metrics-legent-table-color {
+.lv-plugin__metrics-legent-table-color {
   width: 10px;
   height: 10px;
   margin-right: 5px;

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -241,7 +241,7 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
                     <Tr key={series.childName}>
                       <Th isStickyColumn stickyMinWidth="20px" style={{ width: '20px' }}>
                         <div
-                          className="co-logs-metrics-legent-table-color"
+                          className="lv-plugin__metrics-legent-table-color"
                           style={{ backgroundColor: colors?.[index] }}
                         />
                       </Th>

--- a/web/src/components/logs-query-input.css
+++ b/web/src/components/logs-query-input.css
@@ -1,14 +1,14 @@
-.co-logs-expression-input {
+.lv-plugin__expression-input {
   display: flex;
   align-items: flex-start;
 }
 
-.co-logs-expression-input__form {
+.lv-plugin__expression-input__form {
   margin-right: var(--pf-v5-global--spacer--md);
   width: 100%;
 }
 
-textarea.pf-v5-c-form-control.co-logs-expression-input__searchInput {
+textarea.pf-v5-c-form-control.lv-plugin__expression-input__searchInput {
   font-family: var(--pf-v5-c-code-block__pre--FontFamily), monospace;
   font-size: var(--pf-v5-c-code-block__pre--FontSize);
 }

--- a/web/src/components/logs-query-input.tsx
+++ b/web/src/components/logs-query-input.tsx
@@ -51,8 +51,8 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
     !isValid || (invalidQueryErrorMessage !== undefined && invalidQueryErrorMessage !== null);
 
   return (
-    <div className="co-logs-expression-input" data-test={TestIds.LogsQueryInput}>
-      <Form className="co-logs-expression-input__form">
+    <div className="lv-plugin__expression-input" data-test={TestIds.LogsQueryInput}>
+      <Form className="lv-plugin__expression-input__form">
         {hasError && (
           <FormAlert>
             <Alert
@@ -71,7 +71,7 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
         )}
         <FormGroup type="string" fieldId="selection">
           <TextArea
-            className="co-logs-expression-input__searchInput"
+            className="lv-plugin__expression-input__searchInput"
             placeholder="LogQL Query"
             value={internalValue}
             onChange={(_event, text: string) => handleOnChange(text)}

--- a/web/src/components/logs-table.css
+++ b/web/src/components/logs-table.css
@@ -1,4 +1,4 @@
-.co-logs-table .co-logs-table__expand {
+.lv-plugin__table .lv-plugin__table__expand {
   font-size: var(--pf-v5-global--FontSize--sm);
   --pf-v5-c-table--cell--Width: 50px;
   --pf-v5-c-table--cell--MaxWidth: 50px;
@@ -7,13 +7,13 @@
   vertical-align: middle;
 }
 
-.co-logs-table .co-logs-table__details {
+.lv-plugin__table .lv-plugin__table__details {
   font-size: var(--pf-v5-global--FontSize--sm);
   padding: var(--pf-v5-global--spacer--lg);
   display: block;
 }
 
-.co-logs-table .co-logs-table__time {
+.lv-plugin__table .lv-plugin__table__time {
   --pf-v5-c-table--cell--Width: 270px;
   --pf-v5-c-table--cell--MaxWidth: 270px;
   --pf-v5-c-table--cell--MinWidth: 270px;
@@ -25,11 +25,11 @@
   vertical-align: middle;
 }
 
-.co-logs-table .co-logs-table__time-header {
+.lv-plugin__table .lv-plugin__table__time-header {
   font-size: var(--pf-v5-global--FontSize--md);
 }
 
-.co-logs-table .co-logs-table__message {
+.lv-plugin__table .lv-plugin__table__message {
   font-size: var(--pf-v5-global--FontSize--sm);
   padding: var(--pf-v5-global--spacer--xs);
   padding-right: var(--pf-v5-global--spacer--md);
@@ -39,12 +39,12 @@
   width: 100%;
 }
 
-.co-logs-table .co-logs-table__resources {
+.lv-plugin__table .lv-plugin__table__resources {
   --pf-v5-c-table--cell--FontSize: var(--pf-v5-global--FontSize--md);
   margin-top: var(--pf-v5-global--spacer--xs);
 }
 
-.co-logs-table__row::before {
+.lv-plugin__table__row::before {
   content: '';
   display: block;
   position: absolute;
@@ -55,76 +55,76 @@
   background-color: var(--pf-v5-global--disabled-color--200);
 }
 
-.co-logs-table__row--expanded::before {
+.lv-plugin__table__row--expanded::before {
   bottom: 0;
 }
 
-.co-logs-table__row--expanded-details::before {
+.lv-plugin__table__row--expanded-details::before {
   top: 0;
 }
 
-.co-logs-table__severity-critical::before {
+.lv-plugin__table__severity-critical::before {
   background-color: var(--pf-v5-global--palette--purple-500);
 }
 
-.co-logs-table__severity-error::before {
+.lv-plugin__table__severity-error::before {
   background-color: var(--pf-v5-global--danger-color--100);
 }
 
-.co-logs-table__severity-warning::before {
+.lv-plugin__table__severity-warning::before {
   background-color: var(--pf-v5-global--warning-color--100);
 }
 
-.co-logs-table__severity-info::before {
+.lv-plugin__table__severity-info::before {
   background-color: var(--pf-v5-global--palette--green-300);
 }
 
-.co-logs-table__severity-debug::before {
+.lv-plugin__table__severity-debug::before {
   background-color: var(--pf-v5-global--palette--light-blue-400);
 }
 
-.co-logs-table__severity-trace::before {
+.lv-plugin__table__severity-trace::before {
   background-color: var(--pf-v5-global--palette--cyan-200);
 }
 
-.co-logs-table__row-info {
+.lv-plugin__table__row-info {
   font-size: var(--pf-v5-global--FontSize--xs);
   background-color: var(--pf-v5-global--Background-color--100);
   --pf-v5-c-table--cell--PaddingBottom: var(--pf-v5-global--spacer--xs);
   --pf-v5-c-table--cell--PaddingTop: var(--pf-v5-global--spacer--xs);
 }
 
-.co-logs-table__row-info td {
+.lv-plugin__table__row-info td {
   text-align: center;
 }
 
-.co-logs-table__row-info .pf-v5-c-alert {
+.lv-plugin__table__row-info .pf-v5-c-alert {
   text-align: center;
   --pf-v5-c-alert__icon--FontSize: 0.9rem;
 }
 
-.co-logs-table__row-info .pf-v5-c-alert__title {
+.lv-plugin__table__row-info .pf-v5-c-alert__title {
   font-size: 0.8rem;
 }
 
-.co-logs-table__row-more-data td {
+.lv-plugin__table__row-more-data td {
   text-align: center;
   cursor: pointer;
 }
 
-.co-logs-table__row-error,
-.co-logs-table__row-streaming {
+.lv-plugin__table__row-error,
+.lv-plugin__table__row-streaming {
   display: grid;
   justify-content: center;
   justify-items: center;
 }
 
-.co-logs-table__row-header {
+.lv-plugin__table__row-header {
   padding: var(--pf-v5-global--spacer--xs);
   font-size: var(--pf-v5-global--FontSize--md);
   vertical-align: middle;
 }
 
-.pf-v5-c-table .co-logs-table__row.co-logs-table__row--expanded {
+.pf-v5-c-table .lv-plugin__table__row.lv-plugin__table__row--expanded {
   border-bottom: none;
 }

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -106,7 +106,7 @@ const aggregateStreamLogData = (response?: QueryRangeResponse): Array<LogTableDa
 };
 
 const getSeverityClass = (severity: string) => {
-  return severity ? `co-logs-table__severity-${severity}` : '';
+  return severity ? `lv-plugin__table__severity-${severity}` : '';
 };
 
 // sort with an appropriate numeric comparator for big floats
@@ -121,14 +121,14 @@ const columns: Array<TableColumn<LogTableData>> = [
     id: 'expand',
     title: ' ',
     props: {
-      className: 'co-logs-table__expand',
+      className: 'lv-plugin__table__expand',
     },
   },
   {
     id: 'date',
     title: 'Date',
     props: {
-      className: 'co-logs-table__time co-logs-table__time-header',
+      className: 'lv-plugin__table__time lv-plugin__table__time-header',
     },
     sort: (data, sortDirection) =>
       data.sort((a, b) =>
@@ -196,20 +196,20 @@ const TableRow = ({ expandedItems, handleRowToggle, showResources, colSpan }: Ta
       <>
         <Td
           expand={{ isExpanded, onToggle: handleRowToggle, rowIndex: obj.logIndex }}
-          className="co-logs-table__expand"
+          className="lv-plugin__table__expand"
           id="expand"
         />
-        <TableData id="date" activeColumnIDs={activeColumnIDs} className="co-logs-table__time">
+        <TableData id="date" activeColumnIDs={activeColumnIDs} className="lv-plugin__table__time">
           {obj.time}
         </TableData>
         <TableData
           id="message"
           activeColumnIDs={activeColumnIDs}
-          className="co-logs-table__message"
+          className="lv-plugin__table__message"
         >
           <div>{obj.message}</div>
           {showResources && (
-            <Split className="co-logs-table__resources" hasGutter>
+            <Split className="lv-plugin__table__resources" hasGutter>
               {obj.resources?.map((resource) => (
                 <ResourceLinkList key={resource.kind} resource={resource} data={obj} />
               ))}
@@ -219,7 +219,7 @@ const TableRow = ({ expandedItems, handleRowToggle, showResources, colSpan }: Ta
       </>
     ) : isExpanded ? (
       <TableData
-        className="co-logs-table__details"
+        className="lv-plugin__table__details"
         id="expand"
         activeColumnIDs={activeColumnIDs}
         colSpan={colSpan}
@@ -326,7 +326,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({
   };
 
   return (
-    <div data-test={TestIds.LogsTable} className="co-logs-table">
+    <div data-test={TestIds.LogsTable} className="lv-plugin__table">
       {showStats && <StatsTable logsData={logsData} />}
       {children}
 
@@ -341,11 +341,11 @@ export const LogsTable: React.FC<LogsTableProps> = ({
         columns={columns}
         getSortParams={getSortParams}
         getRowClassName={(row) =>
-          `co-logs-table__row ${getSeverityClass(row.severity)} ${
+          `lv-plugin__table__row ${getSeverityClass(row.severity)} ${
             expandedItems.has(row.logIndex)
               ? row.type === 'log'
-                ? 'co-logs-table__row--expanded'
-                : 'co-logs-table__row--expanded-details'
+                ? 'lv-plugin__table__row--expanded'
+                : 'lv-plugin__table__row--expanded-details'
               : ''
           }`
         }

--- a/web/src/components/logs-toolbar.css
+++ b/web/src/components/logs-toolbar.css
@@ -1,12 +1,12 @@
-.co-logs-toolbar {
+.lv-plugin__toolbar {
   gap: var(--pf-v5-global--spacer--md);
 }
 
-.co-logs-severity-filter {
+.lv-plugin__severity-filter {
   margin: 0;
 }
 
-.co-logs-toolbar .co-logs-expression-input {
+.lv-plugin__toolbar .lv-plugin__expression-input {
   padding-right: var(--pf-v5-c-toolbar__content--PaddingRight);
   padding-left: var(--pf-v5-c-toolbar__content--PaddingLeft);
 }

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -155,7 +155,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   );
 
   return (
-    <Toolbar isSticky clearAllFilters={handleClearAllFilters} className="co-logs-toolbar">
+    <Toolbar isSticky clearAllFilters={handleClearAllFilters} className="lv-plugin__toolbar">
       <ToolbarContent>
         {attributeList && (
           <AttributeFilter
@@ -170,7 +170,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             deleteChip={onDeleteSeverityFilter}
             deleteChipGroup={onDeleteSeverityGroup}
             categoryName="Severity"
-            className="co-logs-severity-filter"
+            className="lv-plugin__severity-filter"
             data-test={TestIds.SeverityDropdown}
           >
             <Select

--- a/web/src/components/precision-time-picker.css
+++ b/web/src/components/precision-time-picker.css
@@ -1,12 +1,12 @@
-.co-logs-time-picker__time-options {
+.lv-plugin__time-picker__time-options {
   max-height: 200px;
   overflow: auto;
 }
 
-.co-logs-time-picker__input {
+.lv-plugin__time-picker__input {
   width: 150px;
 }
 
-.co-logs-time-picker__error {
+.lv-plugin__time-picker__error {
   padding-top: 'var(--pf-v5-global--spacer--xs)';
 }

--- a/web/src/components/precision-time-picker.tsx
+++ b/web/src/components/precision-time-picker.tsx
@@ -105,7 +105,7 @@ export const PrecisionTimePicker: React.FC<PrecisionTimePickerProps> = ({ onChan
     <Menu
       id="time-select-menu"
       onSelect={handleMenuSelect}
-      className="co-logs-time-picker__time-options"
+      className="lv-plugin__time-picker__time-options"
       ref={menuRef}
     >
       <MenuContent>
@@ -130,11 +130,11 @@ export const PrecisionTimePicker: React.FC<PrecisionTimePickerProps> = ({ onChan
         aria-label="Precision time picker"
         isRequired
         validated={isValid ? undefined : ValidatedOptions.error}
-        className="co-logs-time-picker__input"
+        className="lv-plugin__time-picker__input"
         ref={inputRef}
       />
       {!isValid && (
-        <HelperText className="co-logs-time-picker__error">
+        <HelperText className="lv-plugin__time-picker__error">
           <HelperTextItem variant="error">{t('Invalid time format')}</HelperTextItem>
         </HelperText>
       )}

--- a/web/src/components/stats-table.css
+++ b/web/src/components/stats-table.css
@@ -1,16 +1,16 @@
-.co-stats-title{
-    font-size: 16px;
+.lv-plugin__stats-title {
+  font-size: 16px;
 }
 
-.co-stats__content{
-    padding: 20px;
-    padding-top: 5px;
-    padding-bottom: 40px;
+.lv-plugin__stats__content {
+  padding: 20px;
+  padding-top: 5px;
+  padding-bottom: 40px;
 }
-.co-stats-table{
-    background: none;
+.lv-plugin__stats-table {
+  background: none;
 }
 
-.co-stats-table__header{
-    width: 205px;
+.lv-plugin__stats-table__header {
+  width: 205px;
 }

--- a/web/src/components/stats-table.tsx
+++ b/web/src/components/stats-table.tsx
@@ -55,15 +55,15 @@ export const StatsTable: React.FC<StatsTableProps> = ({ logsData }) => {
 
   return (
     <div data-test={TestIds.LogsStats}>
-      <div className="co-stats-title">{t('Statistics')}</div>
-      <div className="co-stats__content">
-        <Table className="co-stats-table" variant="compact" aria-label={t('Statistics')}>
+      <div className="lv-plugin__stats-title">{t('Statistics')}</div>
+      <div className="lv-plugin__stats__content">
+        <Table className="lv-plugin__stats-table" variant="compact" aria-label={t('Statistics')}>
           <Thead>
-            <Th className="co-stats-table__header"></Th>
+            <Th className="lv-plugin__stats-table__header"></Th>
             <Th></Th>
-            <Th className="co-stats-table__header"></Th>
+            <Th className="lv-plugin__stats-table__header"></Th>
             <Th></Th>
-            <Th className="co-stats-table__header"></Th>
+            <Th className="lv-plugin__stats-table__header"></Th>
             <Th></Th>
           </Thead>
 

--- a/web/src/components/time-range-select-modal.css
+++ b/web/src/components/time-range-select-modal.css
@@ -1,25 +1,25 @@
-.co-logs-time-range-modal {
+.lv-plugin__time-range-modal {
   --pf-v5-global--FontSize--md: 14px;
 }
 
-.co-logs-time-range-modal__footer {
+.lv-plugin__time-range-modal__footer {
   display: flex;
   gap: var(--pf-v5-global--spacer--sm);
   justify-content: flex-end;
   width: 100%;
 }
 
-.co-logs-time-range-modal__body {
+.lv-plugin__time-range-modal__body {
   overflow: visible;
   display: grid;
   gap: var(--pf-v5-global--spacer--md);
 }
 
-.co-logs-time-range-modal__field {
+.lv-plugin__time-range-modal__field {
   display: flex;
   align-items: flex-start;
 }
 
-.co-logs-time-range-modal__error {
+.lv-plugin__time-range-modal__error {
   margin-top: var(--pf-v5-global--spacer--md);
 }

--- a/web/src/components/time-range-select-modal.tsx
+++ b/web/src/components/time-range-select-modal.tsx
@@ -137,7 +137,7 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
   return (
     <Modal
       id="date-time-picker-modal"
-      className="modal-dialog co-logs-time-range-modal"
+      className="modal-dialog lv-plugin__time-range-modal"
       variant={ModalVariant.small}
       title="Custom time range"
       position="top"
@@ -149,7 +149,7 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
       aria-label="date-time-picker-modal"
       data-test={TestIds.TimeRangeSelectModal}
       footer={
-        <div className="co-logs-time-range-modal__footer">
+        <div className="lv-plugin__time-range-modal__footer">
           <Button
             key="confirm"
             variant="primary"
@@ -166,25 +166,25 @@ export const TimeRangeSelectModal: React.FC<TimeRangeSelectModal> = ({
       }
     >
       <ModalBoxBody
-        className="co-logs-time-range-modal__body"
+        className="lv-plugin__time-range-modal__body"
         data-test={TestIds.TimeRangeSelectModal}
       >
         <div>
           <label>{t('From')}</label>
-          <div className="co-logs-time-range-modal__field">
+          <div className="lv-plugin__time-range-modal__field">
             <DatePicker onChange={handleStartDateChange} value={startDate} />
             <PrecisionTimePicker time={startTime} onChange={handleStartTimeChange} />
           </div>
         </div>
         <div>
           <label>{t('To')}</label>
-          <div className="co-logs-time-range-modal__field">
+          <div className="lv-plugin__time-range-modal__field">
             <DatePicker onChange={handleEndDateChange} value={endDate} />
             <PrecisionTimePicker time={endTime} onChange={handleEndTimeChange} />
           </div>
           {!isRangeValid && (
             <Alert
-              className="co-logs-time-range-modal__error"
+              className="lv-plugin__time-range-modal__error"
               variant="danger"
               isInline
               isPlain

--- a/web/src/components/toggle-button.css
+++ b/web/src/components/toggle-button.css
@@ -1,4 +1,4 @@
-.co-logs-toggle-button {
+.lv-plugin__toggle-button {
   padding-right: var(--pf-v5-global--spacer--xs);
   padding-left: var(--pf-v5-global--spacer--xs);
 }

--- a/web/src/components/toggle-button.tsx
+++ b/web/src/components/toggle-button.tsx
@@ -33,7 +33,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   return (
     <Button
       type="button"
-      className="co-logs-toggle-button"
+      className="lv-plugin__toggle-button"
       onClick={handleToggle}
       variant="link"
       data-test={dataTest}

--- a/web/src/components/toggle-play.css
+++ b/web/src/components/toggle-play.css
@@ -1,7 +1,6 @@
-.co-logs-toggle-play.pf-v5-c-button {
+.lv-plugin__toggle-play.pf-v5-c-button {
   background-color: var(--pf-v5-global--BackgroundColor--100);
-  border: var(--pf-v5-global--BorderWidth--lg) solid
-    var(--pf-v5-global--BorderColor--100);
+  border: var(--pf-v5-global--BorderWidth--lg) solid var(--pf-v5-global--BorderColor--100);
   border-radius: 50%;
   height: 32px;
   padding: 0;
@@ -9,6 +8,6 @@
   cursor: pointer;
 }
 
-.co-logs-toggle-play.pf-v5-c-button.co-logs-toggle-play--active {
+.lv-plugin__toggle-play.pf-v5-c-button.lv-plugin__toggle-play--active {
   border-color: var(--pf-v5-global--palette--green-300);
 }

--- a/web/src/components/toggle-play.tsx
+++ b/web/src/components/toggle-play.tsx
@@ -17,7 +17,7 @@ export const TogglePlay: React.FC<TogglePlayProps> = ({ onClick, active, isDisab
   return (
     <Button
       variant="plain"
-      className={`co-logs-toggle-play ${active ? 'co-logs-toggle-play--active' : ''}`}
+      className={`lv-plugin__toggle-play ${active ? 'lv-plugin__toggle-play--active' : ''}`}
       onClick={onClick}
       aria-label={active ? t('Pause streaming') : t('Start streaming')}
       isDisabled={isDisabled}

--- a/web/src/components/virtualized-logs-table.tsx
+++ b/web/src/components/virtualized-logs-table.tsx
@@ -263,8 +263,8 @@ export const VirtualizedLogsTable = ({
   }, [shouldResize]);
 
   return (
-    <div className="co-logs-virtualized-table">
-      <Table aria-label="Logs Table" variant="compact" className="co-logs-table" isStriped>
+    <div className="lv-plugin__virtualized-table">
+      <Table aria-label="Logs Table" variant="compact" className="lv-plugin__table" isStriped>
         <Thead>
           <Tr>
             {columns.map(({ title, props }, columnIndex) => {
@@ -273,7 +273,7 @@ export const VirtualizedLogsTable = ({
                 <Th
                   sort={sortParams}
                   key={title}
-                  className="co-logs-table__row-header"
+                  className="lv-plugin__table__row-header"
                   {...(props ?? {})}
                 >
                   {title}
@@ -284,9 +284,9 @@ export const VirtualizedLogsTable = ({
         </Thead>
         {error ? (
           <Tbody>
-            <Tr className="co-logs-table__row-info">
+            <Tr className="lv-plugin__table__row-info">
               <Td colSpan={colSpan} key="error-row">
-                <div className="co-logs-table__row-error">
+                <div className="lv-plugin__table__row-error">
                   <ErrorMessage error={error} />
                 </div>
               </Td>
@@ -294,9 +294,9 @@ export const VirtualizedLogsTable = ({
           </Tbody>
         ) : isStreaming ? (
           <Tbody>
-            <Tr className="co-logs-table__row-info">
+            <Tr className="lv-plugin__table__row-info">
               <Td colSpan={colSpan} key="streaming-row">
-                <div className="co-logs-table__row-streaming">
+                <div className="lv-plugin__table__row-streaming">
                   <Alert variant="info" isInline isPlain title={t('Streaming Logs...')} />
                 </div>
               </Td>
@@ -304,7 +304,7 @@ export const VirtualizedLogsTable = ({
           </Tbody>
         ) : isLoading ? (
           <Tbody>
-            <Tr className="co-logs-table__row-info">
+            <Tr className="lv-plugin__table__row-info">
               <Td colSpan={colSpan} key="loading-row">
                 {t('Loading...')}
               </Td>
@@ -313,7 +313,7 @@ export const VirtualizedLogsTable = ({
         ) : (
           dataIsEmpty && (
             <Tbody>
-              <Tr className="co-logs-table__row-info">
+              <Tr className="lv-plugin__table__row-info">
                 <Td colSpan={colSpan} key="data-empty-row">
                   <CenteredContainer>
                     <Alert variant="warning" isInline isPlain title={t('No datapoints found')} />
@@ -354,7 +354,7 @@ export const VirtualizedLogsTable = ({
         {!isLoading && hasMoreLogsData && (
           <Tbody>
             <Tr
-              className="co-logs-table__row-info co-logs-table__row-more-data"
+              className="lv-plugin__table__row-info lv-plugin__table__row-more-data"
               onClick={() => {
                 setScrollToIndex(data.length - 1);
                 onLoadMore?.();

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -83,13 +83,13 @@ const DevConsole = () => {
 
 const EndToEndTestsApp = () => {
   return (
-    <div className="pf-v5-c-page co-logs-standalone__page">
+    <div className="pf-v5-c-page lv-plugin__standalone__page">
       <BrowserRouter>
         <header className="pf-v5-c-masthead">
           <div className="pf-v5-c-masthead__main"></div>
         </header>
 
-        <div className="pf-v5-c-page__sidebar co-logs-standalone__side-menu">
+        <div className="pf-v5-c-page__sidebar lv-plugin__standalone__side-menu">
           <div className="pf-v5-c-page__sidebar-body">
             <nav className="pf-v5-c-nav" aria-label="Global">
               <ul className="pf-v5-c-nav__list">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,7 +1,7 @@
-.co-logs-standalone__page {
+.lv-plugin__standalone__page {
   height: '100vh';
 }
 
-.co-logs-standalone__side-menu {
+.lv-plugin__standalone__side-menu {
   width: '160px';
 }


### PR DESCRIPTION
This PR renames a number of css classes in the logging view plugin to reference the plugin name rather than use the console repo default css class prefix of `co-`