### PR TITLE
NO-JIRA: Add devspace configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ env.list
 hack/docker-compose/docker-compose-logs
 test-certs
 web/cypress/downloads/
+
+
+# Ignore DevSpace cache and log folder
+.devspace/

--- a/Dockerfile.devspace
+++ b/Dockerfile.devspace
@@ -1,0 +1,26 @@
+FROM quay.io/redhat-cne/openshift-origin-release:rhel-9-golang-1.22-openshift-4.17 AS web-builder
+
+WORKDIR /opt/app-root
+
+USER 0
+RUN chgrp -R 0 /opt/app-root
+RUN chmod -R g+rw /opt/app-root
+RUN mkdir /.devspace
+RUN chgrp -R 0 /.devspace
+RUN chmod -R g+rw /.devspace
+
+ENV HUSKY=0
+
+COPY Makefile Makefile
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN make install-backend
+
+COPY config/ config/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN make build-backend
+
+ENTRYPOINT ["make", "start-devspace-backend"]

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,12 @@ start-backend: build-backend
 .PHONY: build-image
 build-image: install-backend build-backend install-frontend build-frontend
 	./scripts/image.sh -t latest
+
+export REGISTRY_ORG?=openshift-observability-ui
+export TAG?=pf5
+IMAGE=quay.io/${REGISTRY_ORG}/logging-view-plugin:${TAG}
+
+deploy:
+	helm uninstall logging-view-plugin -n logging-view-plugin || true
+	PUSH=1 scripts/build-image.sh
+	helm install logging-view-plugin charts/openshift-console-plugin -n logging-view-plugin --create-namespace --set plugin.image=$(IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install-backend:
 
 .PHONY: build-backend
 build-backend:
-	go build $(BUILD_OPTS) -mod=readonly -o plugin-backend -mod=readonly cmd/plugin-backend.go
+	go build $(BUILD_OPTS) -mod=readonly -o plugin-backend cmd/plugin-backend.go
 
 .PHONY: test-unit-backend
 test-unit-backend:
@@ -59,12 +59,16 @@ start-frontend:
 start-backend: build-backend
 	./plugin-backend -port 9002 -features "$(FEATURES)"
 
+.PHONY: start-devspace-backend
+start-devspace-backend:
+	/opt/app-root/plugin-backend -port=9443 -cert=/var/serving-cert/tls.crt -key=/var/serving-cert/tls.key -plugin-config-path=/etc/plugin/config.yaml -static-path=/opt/app-root/web/dist -config-path=/opt/app-root/config
+
 .PHONY: build-image
-build-image: install-backend build-backend install-frontend build-frontend
+build-image:
 	./scripts/image.sh -t latest
 
 export REGISTRY_ORG?=openshift-observability-ui
-export TAG?=pf5
+export TAG?=latest
 IMAGE=quay.io/${REGISTRY_ORG}/logging-view-plugin:${TAG}
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,23 @@ to `http://localhost:3100`. You can disable this by re-running the console with
 
 Navigate to <http://localhost:9000/monitoring/logs> to see the running plugin.
 
+### Running using Devspace
+
+Install the [devspace](https://www.devspace.sh/docs/getting-started/installation) cli.
+
+1. Create and install a LokiStack in your cluster collecting logs
+2. Install the dependencies running `make install`
+3. Start the frontend `make start-frontend`
+4. Select the namespace you want to deploy in using `devspace use namespace {NAMESPACE}`. If you are attempting to take over a COO deployment, make sure to set the namespace where the plugin has been deployed.
+4. In a different terminal start the devspace sync `devspace dev`
+
+If helm is selected in the `devspace dev` command, this will run and deploy the logging-view-plugin in the cluster using the helm chart for this repository. It will then "take over" the logging-view-plugin pod, grabbing all of the certificates and backend binary and configuration to run in the devspace pod. If helm isn't selected, the pipeline will attempt to run the `scale_down_coo` function to prevent COO from fighting over the pod. Devspace then begins a sync process which will mirror changes from the `/web/dist` folder into the `/opt/app-root/web/dist` folder in the devspace pod. You can then make changes to your frontend files locally and have webpack rebuild the `/web/dist` folder, have the files be re-synced, and reload your console webpage to see your local changes running in the cluster.
+
+After development you can run `devspace purge` to cleanup. When helm is not selected, scale_up_coo will then be called.
+
 ### Local Development Troubleshooting
 1. Disable cache. Select 'disable cache' in your browser's DevTools > Network > 'disable cache'. Or use private/incognito mode in your browser.
-2. Enable higher log verbosity by setting `-log-level=trace` when starting the plugin backend. For more options to set log level see [logrus documentation](https://github.com/sirupsen/logrus?tab=readme-ov-file#level-logging). 
+2. Enable higher log verbosity by setting `-log-level=trace` when starting the plugin backend. For more options to set log level see [logrus documentation](https://github.com/sirupsen/logrus?tab=readme-ov-file#level-logging).
 
 ### Running tests
 

--- a/charts/openshift-console-plugin/.helmignore
+++ b/charts/openshift-console-plugin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/openshift-console-plugin/Chart.yaml
+++ b/charts/openshift-console-plugin/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: openshift-console-plugin
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/charts/openshift-console-plugin/templates/_helpers.tpl
+++ b/charts/openshift-console-plugin/templates/_helpers.tpl
@@ -31,7 +31,7 @@ Selector labels
 {{- define "openshift-console-plugin.selectorLabels" -}}
 app: {{ include "openshift-console-plugin.name" . }}
 app.kubernetes.io/name: {{ include "openshift-console-plugin.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: logging
 app.kubernetes.io/part-of: {{ include "openshift-console-plugin.name" . }}
 {{- end }}
 

--- a/charts/openshift-console-plugin/templates/_helpers.tpl
+++ b/charts/openshift-console-plugin/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openshift-console-plugin.name" -}}
+{{- default (default .Chart.Name .Release.Name) .Values.plugin.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openshift-console-plugin.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openshift-console-plugin.labels" -}}
+helm.sh/chart: {{ include "openshift-console-plugin.chart" . }}
+{{ include "openshift-console-plugin.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openshift-console-plugin.selectorLabels" -}}
+app: {{ include "openshift-console-plugin.name" . }}
+app.kubernetes.io/name: {{ include "openshift-console-plugin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ include "openshift-console-plugin.name" . }}
+{{- end }}
+
+{{/*
+Create the name secret containing the certificate
+*/}}
+{{- define "openshift-console-plugin.certificateSecret" -}}
+{{ default (printf "%s-cert" (include "openshift-console-plugin.name" .)) .Values.plugin.certificateSecretName }}
+{{- end }}
+
+{{/*
+Create the name secret containing the certificate
+*/}}
+{{- define "openshift-console-plugin.pluginConfigName" -}}
+{{ default (printf "%s-cert" (include "openshift-console-plugin.name" .)) .Values.plugin.pluginConfigName }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openshift-console-plugin.serviceAccountName" -}}
+{{- if .Values.plugin.serviceAccount.create }}
+{{- default (include "openshift-console-plugin.name" .) .Values.plugin.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.plugin.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the patcher
+*/}}
+{{- define "openshift-console-plugin.patcherName" -}}
+{{- printf "%s-patcher" (include "openshift-console-plugin.name" .) }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openshift-console-plugin.patcherServiceAccountName" -}}
+{{- if .Values.plugin.patcherServiceAccount.create }}
+{{- default (printf "%s-patcher" (include "openshift-console-plugin.name" .)) .Values.plugin.patcherServiceAccount.name }}
+{{- else }}
+{{- default "default" .Values.plugin.patcherServiceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/openshift-console-plugin/templates/configmap.yaml
+++ b/charts/openshift-console-plugin/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openshift-console-plugin.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    timeout: "30s"

--- a/charts/openshift-console-plugin/templates/consoleplugin.yaml
+++ b/charts/openshift-console-plugin/templates/consoleplugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: {{ template "openshift-console-plugin.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+spec:
+  displayName: {{ default (printf "%s Plugin" (include "openshift-console-plugin.name" .)) .Values.plugin.description }}
+  backend:
+    type: Service
+    service:
+      name: {{ template "openshift-console-plugin.name" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.plugin.port }}
+      basePath: {{ .Values.plugin.basePath }}
+  proxy:
+  - alias: backend
+    authorization: UserToken
+    endpoint:
+      type: Service
+      service:
+        name: logging-loki-gateway-http
+        namespace: openshift-logging
+        port: 8080

--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openshift-console-plugin.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+    app.openshift.io/runtime-namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.plugin.replicas }}
+  selector:
+    matchLabels:
+      {{- include "openshift-console-plugin.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+            {{- include "openshift-console-plugin.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ template "openshift-console-plugin.name" . }}
+          image: {{ required "Plugin image must be specified!" .Values.plugin.image }}
+          args:
+            - "-port={{ .Values.plugin.port }}"
+            - "-cert=/var/serving-cert/tls.crt"
+            - "-key=/var/serving-cert/tls.key"
+            - "-plugin-config-path=/etc/plugin/config.yaml"
+            - "-static-path=/opt/app-root/web/dist"
+            - "-config-path=/opt/app-root/config"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: {{ .Values.plugin.port }}
+              protocol: TCP
+          imagePullPolicy: Always
+          resources:
+            {{- toYaml .Values.plugin.resources | nindent 12 }}
+          volumeMounts:
+            - name: plugin-cert
+              readOnly: true
+              mountPath: /var/serving-cert
+            - name: plugin-conf
+              readOnly: true
+              mountPath: /etc/plugin
+      volumes:
+        - name: plugin-cert
+          secret:
+            secretName: {{ template "openshift-console-plugin.certificateSecret" . }}
+            defaultMode: 420
+        - name: plugin-conf
+          configMap:
+            name: {{ template "openshift-console-plugin.name" . }}
+            defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/charts/openshift-console-plugin/templates/patch-consoles-job.yaml
+++ b/charts/openshift-console-plugin/templates/patch-consoles-job.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.plugin.jobs.patchConsoles.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "openshift-console-plugin.patcherName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        {{- include "openshift-console-plugin.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "openshift-console-plugin.patcherServiceAccountName" . }}
+      {{- if  and (.Values.plugin.securityContext.enabled) (.Values.plugin.jobs.patchConsoles.podSecurityContext.enabled) }}
+      securityContext: {{ tpl (toYaml (omit .Values.plugin.jobs.patchConsoles.podSecurityContext "enabled")) $ | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 400
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: {{ template "openshift-console-plugin.patcherName" . }}
+          image: {{ required "Patcher image must be specified!" .Values.plugin.jobs.patchConsoles.image }}
+          {{- if and (.Values.plugin.securityContext.enabled) (.Values.plugin.containerSecurityContext) }}
+          securityContext: {{ tpl (toYaml (omit .Values.plugin.jobs.patchConsoles.containerSecurityContext "enabled")) $ | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.plugin.jobs.patchConsoles.resources | nindent 12 }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+                existingPlugins=$(oc get consoles.operator.openshift.io cluster -o json | jq -c '.spec.plugins // []')
+                mergedPlugins=$(jq --argjson existingPlugins "${existingPlugins}" --argjson consolePlugin '["{{ template "openshift-console-plugin.name" . }}"]' -c  -n '$existingPlugins + $consolePlugin | unique')
+                patchedPlugins=$(jq --argjson mergedPlugins $mergedPlugins -n -c  '{ "spec": { "plugins": $mergedPlugins } }')
+                oc patch consoles.operator.openshift.io cluster --patch $patchedPlugins  --type=merge
+{{- end }}

--- a/charts/openshift-console-plugin/templates/patcher-clusterrole.yaml
+++ b/charts/openshift-console-plugin/templates/patcher-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.plugin.jobs.patchConsoles.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "openshift-console-plugin.patcherName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["operator.openshift.io"]
+    resources: ["consoles"]
+    verbs: ["get","list","patch", "update"]
+{{- end }}

--- a/charts/openshift-console-plugin/templates/patcher-clusterrolebinding.yaml
+++ b/charts/openshift-console-plugin/templates/patcher-clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.plugin.jobs.patchConsoles.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "openshift-console-plugin.patcherName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "openshift-console-plugin.patcherName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "openshift-console-plugin.patcherServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/openshift-console-plugin/templates/patcher-serviceaccount.yaml
+++ b/charts/openshift-console-plugin/templates/patcher-serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.plugin.patcherServiceAccount.create) (.Values.plugin.jobs.patchConsoles.enabled) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openshift-console-plugin.patcherServiceAccountName" . }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+  {{- with .Values.plugin.patcherServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openshift-console-plugin/templates/service.yaml
+++ b/charts/openshift-console-plugin/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if not .Values.certificateSecretName }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: {{ template "openshift-console-plugin.certificateSecret" . }}
+  {{- end }}
+  name: {{ template "openshift-console-plugin.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: "{{ .Values.plugin.port }}-tcp"
+      protocol: TCP
+      port: {{ .Values.plugin.port }}
+      targetPort: {{ .Values.plugin.port }}
+  selector:
+    {{- include "openshift-console-plugin.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  sessionAffinity: None

--- a/charts/openshift-console-plugin/templates/serviceaccount.yaml
+++ b/charts/openshift-console-plugin/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.plugin.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openshift-console-plugin.serviceAccountName" . }}
+  labels:
+    {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+  {{- with .Values.plugin.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -1,0 +1,55 @@
+---
+plugin:
+  name: logging-view-plugin
+  description: Logging view Plugin
+  image: quay.io/openshift-observability-ui/logging-view-plugin:latest
+  imagePullPolicy: IfNotPresent
+  replicas: 1
+  port: 9443
+  securityContext:
+    enabled: true
+  podSecurityContext:
+    enabled: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+  basePath: /
+  certificateSecretName: plugin-serving-cert
+  pluginConfigName: logging-view-plugin-config
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  patcherServiceAccount:
+    create: true
+    annotations: {}
+    name: ""
+  jobs:
+    patchConsoles:
+      enabled: true
+      image: "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:af22cf89b7f1791b943f507d15c62ed5265d7390b24ab598eefe34f63c07fa9d"
+      podSecurityContext:
+        enabled: true
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 10m
+          memory: 50Mi

--- a/devspace-deployment.yaml
+++ b/devspace-deployment.yaml
@@ -1,0 +1,14 @@
+# This is a list of `deployments` that DevSpace can create for this project
+app:
+  # This deployment uses `helm` but you can also define `kubectl` deployments or kustomizations
+  helm:
+    # We are deploying this project with the Helm chart you provided
+    chart:
+      name: ./charts/openshift-console-plugin
+    # Under `values` we can define the values for this Helm chart used during `helm install/upgrade`
+    # You may also use `valuesFiles` to load values from files, e.g. valuesFiles: ["values.yaml"]
+    valuesFiles: ["./charts/openshift-console-plugin/values.yaml"]
+    values:
+      plugin:
+        image: "quay.io/rh-ee-pyurkovi/logging-view-plugin:pf5"
+  namespace: ${DEVSPACE_NAMESPACE}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,0 +1,52 @@
+version: v2beta1
+name: logging-view-plugin
+
+vars:
+  USE_HELM:
+    question: Do you want to deploy using helm? (y/[n])
+    default: "n"
+    noCache: true
+
+functions:
+  scale_down_coo: |-
+    kubectl scale --replicas=0 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
+  scale_up_coo: |-
+    kubectl scale --replicas=1 -n ${DEVSPACE_NAMESPACE} deployment/observability-operator
+
+# This is a list of `pipelines` that DevSpace can execute (you can define your own)
+pipelines:
+  # This is the pipeline for the main command: `devspace dev` (or `devspace run-pipeline dev`)
+  dev:
+    run: |-
+      run_dependencies --all       # 1. Deploy any projects this project needs (see "dependencies")
+      ensure_pull_secrets --all    # 2. Ensure pull secrets
+      scale_down_coo               # 3. Scale down COO so it doesn't fight over the logging-view-plugin if you aren't using helm
+      create_deployments --all     # 4. Deploy Helm charts and manifests specfied as "deployments"
+      start_dev app                # 5. Start dev mode "app" (see "dev" section)
+  purge:
+    run: |-
+      stop_dev --all
+      purge_deployments --all
+      run_dependencies --all --pipeline purge
+      scale_up_coo
+
+deployments: $( [ ${USE_HELM} == "y" ] && cat devspace-deployment.yaml || echo "app:")
+
+# This is a list of `dev` containers that are based on the containers created by your deployments
+dev:
+  app:
+    # Search for the container that runs this image
+    labelSelector:
+      # Use the instance selector that COO & helm add
+      app.kubernetes.io/instance: logging
+    # Replace the container image with this dev-optimized image (allows to skip image building during development)
+    devImage: quay.io/rh-ee-pyurkovi/logging-view-plugin:devspace
+    # Sync files between the local filesystem and the development container
+    sync:
+      - path: ./web/dist:/opt/app-root/web/dist
+        startContainer: true
+    command: ["make"]
+    args: ["start-devspace-backend"]
+    # Inject a lightweight SSH server into the container (so your IDE can connect to the remote dev env)
+    ssh:
+      enabled: true

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set +e  # Continue on errors
+
+export NODE_ENV=development
+npm install
+
+COLOR_BLUE="\033[0;94m"
+COLOR_GREEN="\033[0;92m"
+COLOR_RESET="\033[0m"
+
+# Print useful output for user
+echo -e "${COLOR_BLUE}
+     %########%
+     %###########%       ____                 _____
+         %#########%    |  _ \   ___ __   __ / ___/  ____    ____   ____ ___
+         %#########%    | | | | / _ \\\\\ \ / / \___ \ |  _ \  / _  | / __// _ \\
+     %#############%    | |_| |(  __/ \ V /  ____) )| |_) )( (_| |( (__(  __/
+     %#############%    |____/  \___|  \_/   \____/ |  __/  \__,_| \___\\\\\___|
+ %###############%                                  |_|
+ %###########%${COLOR_RESET}
+
+
+Welcome to your development container!
+
+This is how you can work with it:
+- Files will be synchronized between your local machine and this container
+- Some ports will be forwarded, so you can access this container via localhost
+- Run \`${COLOR_GREEN}npm start${COLOR_RESET}\` to start the application
+"
+
+# Set terminal prompt
+export PS1="\[${COLOR_BLUE}\]devspace\[${COLOR_RESET}\] ./\W \[${COLOR_BLUE}\]\\$\[${COLOR_RESET}\] "
+if [ -z "$BASH" ]; then export PS1="$ "; fi
+
+# Include project's bin/ folder in PATH
+export PATH="./bin:$PATH"
+
+# Open shell
+bash --norc


### PR DESCRIPTION
This PR looks to add a better set of development environments. This is completed through the use of 2 actions:

1. Add a helm chart to deploy the logging-view-plugin
2. Add devspace commands `devspace dev` and `devspace purge` to sync a webpack dev server output up into the cluster.

More information can be found in the README doc.