### PR TITLE
OU-676: Use OTel fields for displaying resource information in Log Console

### DIFF
--- a/web/src/__tests__/parse-resource.spec.ts
+++ b/web/src/__tests__/parse-resource.spec.ts
@@ -1,0 +1,96 @@
+import { parseResources } from '../parse-resources';
+
+const mixedData = {
+  __error__: 'JSONParserErr',
+  __error_details__: "Value looks like object, but can't find closing '}' symbol",
+  k8s_container_name: 'klusterlet-agent-otel-test',
+  k8s_namespace_name: 'open-cluster-management-agent-otel-test',
+  k8s_node_name: 'ip-10-0-42-168.ec2.internal',
+  k8s_pod_label_app: 'klusterlet-agent',
+  k8s_pod_label_pod_template_hash: '7df874f76f',
+  k8s_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-otel-test',
+  k8s_pod_uid: '0fab9ca9-97cc-4598-a525-e4fa5774d62c',
+  kubernetes_container_name: 'klusterlet-agent-viaq-test',
+  kubernetes_host: 'ip-10-0-42-168.ec2.internal',
+  kubernetes_namespace_name: 'open-cluster-management-agent-viaq-test',
+  kubernetes_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-viaq-test',
+  level: 'info',
+  log_iostream: 'stderr',
+  log_source: 'container',
+  log_type: 'application',
+  observed_timestamp: '1743697964398933611',
+  openshift_cluster_id: '6aac5cf3-d9ee-4a8d-bc5d-921b8278c7bb',
+  openshift_cluster_uid: '6aac5cf3-d9ee-4a8d-bc5d-921b8278c7bb',
+  openshift_log_source: 'container',
+  openshift_log_type: 'application',
+  severity_text: 'info',
+};
+
+const viaqData = {
+  kubernetes_container_name: 'klusterlet-agent-viaq-test',
+  kubernetes_namespace_name: 'open-cluster-management-agent-viaq-test',
+  kubernetes_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-viaq-test',
+};
+
+const otelData = {
+  k8s_container_name: 'klusterlet-agent-otel-test',
+  k8s_namespace_name: 'open-cluster-management-agent-otel-test',
+  k8s_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-otel-test',
+};
+
+describe('Parse Resources Namespace, Name, Pod', () => {
+  it('Should parse OpenTelemtry stream labels', () => {
+    const resources = parseResources(otelData);
+    const expectOtel = [
+      {
+        kind: 'Namespace',
+        name: 'open-cluster-management-agent-otel-test',
+      },
+      {
+        kind: 'Pod',
+        name: 'klusterlet-agent-7df874f76f-2kc4l-otel-test',
+      },
+      {
+        kind: 'Container',
+        name: 'klusterlet-agent-otel-test',
+      },
+    ];
+    expect(resources).toEqual(expectOtel);
+  });
+  it('Should parse ViaQ stream labels', () => {
+    const resources = parseResources(viaqData);
+    const expectViaQ = [
+      {
+        kind: 'Namespace',
+        name: 'open-cluster-management-agent-viaq-test',
+      },
+      {
+        kind: 'Pod',
+        name: 'klusterlet-agent-7df874f76f-2kc4l-viaq-test',
+      },
+      {
+        kind: 'Container',
+        name: 'klusterlet-agent-viaq-test',
+      },
+    ];
+    expect(resources).toEqual(expectViaQ);
+  });
+  it('Should parse OpenTelemetry stream labels first when both sets of stream labels are present', () => {
+    const resources = parseResources(mixedData);
+    const expectOtel = [
+      {
+        kind: 'Namespace',
+        name: 'open-cluster-management-agent-otel-test',
+      },
+      {
+        kind: 'Pod',
+        name: 'klusterlet-agent-7df874f76f-2kc4l-otel-test',
+      },
+      {
+        kind: 'Container',
+        name: 'klusterlet-agent-otel-test',
+      },
+    ];
+    expect(resources).toEqual(expectOtel);
+  });
+});

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -14,11 +14,11 @@ import {
 } from '../logs.types';
 import { severityFromString } from '../severity';
 import { TestIds } from '../test-ids';
-import { notUndefined } from '../value-utils';
 import { LogDetail } from './log-detail';
 import './logs-table.css';
 import { StatsTable } from './stats-table';
 import { TableData, VirtualizedLogsTable } from './virtualized-logs-table';
+import { parseResources } from '../parse-resources';
 
 interface LogsTableProps {
   logsData?: QueryRangeResponse;
@@ -40,61 +40,6 @@ const isJSONObject = (value: string): boolean => {
   const trimmedValue = value.trim();
 
   return trimmedValue.startsWith('{') && trimmedValue.endsWith('}');
-};
-
-enum KindLabel {
-  Container = 'Container',
-  Namespace = 'Namespace',
-  Pod = 'Pod',
-}
-
-enum OtelStreamLabel {
-  ContainerName = 'k8s_container_name',
-  Namespace = 'k8s_namespace_name',
-  PodName = 'k8s_pod_name',
-}
-
-enum ViaQStreamLabel {
-  ContainerName = 'kubernetes_container_name',
-  Namespace = 'k8s_namespace_name',
-  PodName = 'k8s_pod_name',
-}
-
-const parse = (
-  data: Record<string, string>,
-  labelKind: KindLabel,
-  otelStreamLabel: OtelStreamLabel,
-  viaqStreamLabel: ViaQStreamLabel,
-) => {
-  if (data[otelStreamLabel]) {
-    return {
-      kind: labelKind,
-      name: data[otelStreamLabel],
-    };
-  } else if (data[viaqStreamLabel]) {
-    return {
-      kind: labelKind,
-      name: data[viaqStreamLabel],
-    };
-  }
-  return undefined;
-};
-
-const parseResources = (data: Record<string, string>): Array<Resource> => {
-  const container = parse(
-    data,
-    KindLabel.Container,
-    OtelStreamLabel.ContainerName,
-    ViaQStreamLabel.ContainerName,
-  );
-  const namespace = parse(
-    data,
-    KindLabel.Namespace,
-    OtelStreamLabel.Namespace,
-    ViaQStreamLabel.Namespace,
-  );
-  const pod = parse(data, KindLabel.Pod, OtelStreamLabel.PodName, ViaQStreamLabel.PodName);
-  return [namespace, pod, container].filter(notUndefined);
 };
 
 const streamToTableData = (stream: StreamLogData): Array<LogTableData> => {

--- a/web/src/parse-resources.tsx
+++ b/web/src/parse-resources.tsx
@@ -1,0 +1,57 @@
+import { Resource } from './logs.types';
+import { notUndefined } from './value-utils';
+
+export enum KindLabel {
+  Container = 'Container',
+  Namespace = 'Namespace',
+  Pod = 'Pod',
+}
+
+export enum OtelStreamLabel {
+  ContainerName = 'k8s_container_name',
+  Namespace = 'k8s_namespace_name',
+  PodName = 'k8s_pod_name',
+}
+
+export enum ViaQStreamLabel {
+  ContainerName = 'kubernetes_container_name',
+  Namespace = 'kubernetes_namespace_name',
+  PodName = 'kubernetes_pod_name',
+}
+
+export const parse = (
+  data: Record<string, string>,
+  labelKind: KindLabel,
+  otelStreamLabel: OtelStreamLabel,
+  viaqStreamLabel: ViaQStreamLabel,
+) => {
+  if (data[otelStreamLabel]) {
+    return {
+      kind: labelKind,
+      name: data[otelStreamLabel],
+    };
+  } else if (data[viaqStreamLabel]) {
+    return {
+      kind: labelKind,
+      name: data[viaqStreamLabel],
+    };
+  }
+  return undefined;
+};
+
+export const parseResources = (data: Record<string, string>): Array<Resource> => {
+  const container = parse(
+    data,
+    KindLabel.Container,
+    OtelStreamLabel.ContainerName,
+    ViaQStreamLabel.ContainerName,
+  );
+  const namespace = parse(
+    data,
+    KindLabel.Namespace,
+    OtelStreamLabel.Namespace,
+    ViaQStreamLabel.Namespace,
+  );
+  const pod = parse(data, KindLabel.Pod, OtelStreamLabel.PodName, ViaQStreamLabel.PodName);
+  return [namespace, pod, container].filter(notUndefined);
+};

--- a/web/src/parse-resources.tsx
+++ b/web/src/parse-resources.tsx
@@ -1,57 +1,47 @@
 import { Resource } from './logs.types';
 import { notUndefined } from './value-utils';
 
-export enum KindLabel {
+export enum ResourceLabel {
   Container = 'Container',
   Namespace = 'Namespace',
   Pod = 'Pod',
 }
 
-export enum OtelStreamLabel {
-  ContainerName = 'k8s_container_name',
-  Namespace = 'k8s_namespace_name',
-  PodName = 'k8s_pod_name',
-}
+const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string }> = {
+  [ResourceLabel.Container]: {
+    otel: 'k8s_container_name',
+    viaq: 'kubernetes_container_name',
+  },
+  [ResourceLabel.Namespace]: {
+    otel: 'k8s_namespace_name',
+    viaq: 'kubernetes_namespace_name',
+  },
+  [ResourceLabel.Pod]: {
+    otel: 'k8s_pod_name',
+    viaq: 'kubernetes_pod_name',
+  },
+};
 
-export enum ViaQStreamLabel {
-  ContainerName = 'kubernetes_container_name',
-  Namespace = 'kubernetes_namespace_name',
-  PodName = 'kubernetes_pod_name',
-}
-
-export const parse = (
-  data: Record<string, string>,
-  labelKind: KindLabel,
-  otelStreamLabel: OtelStreamLabel,
-  viaqStreamLabel: ViaQStreamLabel,
-) => {
-  if (data[otelStreamLabel]) {
+const parse = (data: Record<string, string>, resourceLabel: ResourceLabel) => {
+  const resource = ResourceToStreamLabels[resourceLabel];
+  if (data[resource.otel]) {
     return {
-      kind: labelKind,
-      name: data[otelStreamLabel],
+      kind: resourceLabel,
+      name: data[resource.otel],
     };
-  } else if (data[viaqStreamLabel]) {
+  } else if (data[resource.viaq]) {
     return {
-      kind: labelKind,
-      name: data[viaqStreamLabel],
+      kind: resourceLabel,
+      name: data[resource.viaq],
     };
+  } else {
+    return undefined;
   }
-  return undefined;
 };
 
 export const parseResources = (data: Record<string, string>): Array<Resource> => {
-  const container = parse(
-    data,
-    KindLabel.Container,
-    OtelStreamLabel.ContainerName,
-    ViaQStreamLabel.ContainerName,
-  );
-  const namespace = parse(
-    data,
-    KindLabel.Namespace,
-    OtelStreamLabel.Namespace,
-    ViaQStreamLabel.Namespace,
-  );
-  const pod = parse(data, KindLabel.Pod, OtelStreamLabel.PodName, ViaQStreamLabel.PodName);
+  const namespace = parse(data, ResourceLabel.Namespace);
+  const pod = parse(data, ResourceLabel.Pod);
+  const container = parse(data, ResourceLabel.Container);
   return [namespace, pod, container].filter(notUndefined);
 };


### PR DESCRIPTION
### JIRA 
https://issues.redhat.com/browse/OU-676

### Context 
Support stream labels from ViaQ (old data model) and OpenTelemetry (new data model) to display resource information in logging-view-plugin. 

| Resource Required                 | ViaQ Stream Label                       | OpenTelemetry Stream Label  |
|-----------------------------|---------------------------------|-------------------------------|
| Namespace                            | kubernetes_namespace_name   | k8s_namespace_name             |
| Pod Name                               | kubernetes_pod_name               | k8s_pod_name                          |
| Container Name                     | k8s_container_name                   | k8s_container_name                 |

### Manual testing 
**Acceptance Criteria**: Resource links still navigate to the correct pages and the Resources are displayed correctly. They are circled in red for reference. 
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/00644788-4f01-4e9a-a828-b5cce09004a2" />
**Figure 1.** Logging-view-plugin with `ShowResources` clicked. Circled are the resources that display the namespace, pod name, and container name.  
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/27634472-e769-46b3-9987-874096ce4740" />
**Figure 2.** Zoomed out view of Figure 1. 
 
#### Setup: 
-  Deploy logging-view-plugin and the necessary logging component. You can use these [configuration files](https://github.com/zhuje/development-tools/tree/main/logging); run the script `./start.sh`. 
- The script will create a CLI prompt asking you to choose a data model a) otel b) viaq. Choose 'a'  this will configure ClusterLogForwarder to use OpenTelemetry. 
- Then you can access the 'Observe > Logs > Show Resources' button to display the resources circled in Figure 1. 

### Unit test 
To run the new unit test: 
```
cd logging-view-plugin/web/src/__tests__
npx jest parse-resource.spec.ts 
```


