### PR TITLE
OU-677: Extract log information from OTel attributes

### DIFF
--- a/web/src/__tests__/parse-resource.spec.ts
+++ b/web/src/__tests__/parse-resource.spec.ts
@@ -1,4 +1,4 @@
-import { parseResources } from '../parse-resources';
+import { parseResources, parseName, ResourceLabel } from '../parse-resources';
 
 const mixedData = {
   __error__: 'JSONParserErr',
@@ -30,12 +30,14 @@ const viaqData = {
   kubernetes_container_name: 'klusterlet-agent-viaq-test',
   kubernetes_namespace_name: 'open-cluster-management-agent-viaq-test',
   kubernetes_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-viaq-test',
+  level: 'warning-viaq-test',
 };
 
 const otelData = {
   k8s_container_name: 'klusterlet-agent-otel-test',
   k8s_namespace_name: 'open-cluster-management-agent-otel-test',
   k8s_pod_name: 'klusterlet-agent-7df874f76f-2kc4l-otel-test',
+  severity_text: 'warning-otel-test',
 };
 
 describe('Parse Resources Namespace, Name, Pod', () => {
@@ -92,5 +94,20 @@ describe('Parse Resources Namespace, Name, Pod', () => {
       },
     ];
     expect(resources).toEqual(expectOtel);
+  });
+});
+
+describe('Test parseName ', () => {
+  it('Should parse OpenTelemtry stream labels ', () => {
+    const severity = parseName(otelData, ResourceLabel.Severity);
+    expect(severity).toEqual(otelData.severity_text);
+  });
+  it('Should parse ViaQ stream labels ', () => {
+    const severity = parseName(viaqData, ResourceLabel.Severity);
+    expect(severity).toEqual(viaqData.level);
+  });
+  it('Should parse OpenTelemetry stream labels first when both sets of stream labels are present', () => {
+    const severity = parseName(otelData, ResourceLabel.Severity);
+    expect(severity).toEqual(otelData.severity_text);
   });
 });

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -18,7 +18,7 @@ import { LogDetail } from './log-detail';
 import './logs-table.css';
 import { StatsTable } from './stats-table';
 import { TableData, VirtualizedLogsTable } from './virtualized-logs-table';
-import { parseResources } from '../parse-resources';
+import { ResourceLabel, parseResources, parseName } from '../parse-resources';
 
 interface LogsTableProps {
   logsData?: QueryRangeResponse;
@@ -51,16 +51,19 @@ const streamToTableData = (stream: StreamLogData): Array<LogTableData> => {
     const timestamp = parseFloat(String(value[0]));
     const time = timestamp / 1e6;
     const formattedTime = dateToFormat(time, DateFormat.Full);
+    const severity = parseName(stream.stream, ResourceLabel.Severity);
+    const namespace = parseName(stream.stream, ResourceLabel.Namespace);
+    const podName = parseName(stream.stream, ResourceLabel.Pod);
 
     return {
       time: formattedTime,
       timestamp,
       message,
-      severity: severityFromString(stream.stream.level) ?? 'other',
+      severity: severityFromString(severity) ?? 'other',
       data: stream.stream,
       resources: parseResources(stream.stream),
-      namespace: stream.stream['kubernetes_namespace_name'],
-      podName: stream.stream['kubernetes_pod_name'],
+      namespace,
+      podName,
       type: 'log',
       // index is 0 here to match the type, but it will be recalculated when flattening the array
       logIndex: 0,

--- a/web/src/parse-resources.tsx
+++ b/web/src/parse-resources.tsx
@@ -5,6 +5,7 @@ export enum ResourceLabel {
   Container = 'Container',
   Namespace = 'Namespace',
   Pod = 'Pod',
+  Severity = 'Severity',
 }
 
 const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string }> = {
@@ -20,9 +21,13 @@ const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string
     otel: 'k8s_pod_name',
     viaq: 'kubernetes_pod_name',
   },
+  [ResourceLabel.Severity]: {
+    otel: 'severity_text',
+    viaq: 'level',
+  },
 };
 
-const parse = (data: Record<string, string>, resourceLabel: ResourceLabel) => {
+export const parse = (data: Record<string, string>, resourceLabel: ResourceLabel) => {
   const resource = ResourceToStreamLabels[resourceLabel];
   if (data[resource.otel]) {
     return {
@@ -44,4 +49,11 @@ export const parseResources = (data: Record<string, string>): Array<Resource> =>
   const pod = parse(data, ResourceLabel.Pod);
   const container = parse(data, ResourceLabel.Container);
   return [namespace, pod, container].filter(notUndefined);
+};
+
+export const parseName = (
+  data: Record<string, string>,
+  resourceLabel: ResourceLabel,
+): string | undefined => {
+  return parse(data, resourceLabel)?.name;
 };

--- a/web/src/parse-resources.tsx
+++ b/web/src/parse-resources.tsx
@@ -27,7 +27,7 @@ const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string
   },
 };
 
-export const parse = (data: Record<string, string>, resourceLabel: ResourceLabel) => {
+const parse = (data: Record<string, string>, resourceLabel: ResourceLabel) => {
   const resource = ResourceToStreamLabels[resourceLabel];
   if (data[resource.otel]) {
     return {


### PR DESCRIPTION
### JIRA 
https://issues.redhat.com/browse/OU-677

### Context 
Support stream labels from ViaQ (old data model) and OpenTelemetry (new data model) to display severity/level information in logging-view-plugin. 

| Resource Required                 | ViaQ Stream Label                       | OpenTelemetry Stream Label  |
|-----------------------------|---------------------------------|-------------------------------|
| Severity                                   | severity_text                                 | level        |


### Manual Testing 
#### Acceptance Criteria:
Logs tags with the correct CSS based on the severity level. See below for the CSS labels and the corresponding background colors. 

.lv-plugin__table__severity-critical::before {
  background-color: var(--pf-v5-global--palette--purple-500);
}
.lv-plugin__table__severity-error::before {
  background-color: var(--pf-v5-global--danger-color--100);
}
.lv-plugin__table__severity-warning::before {
  background-color: var(--pf-v5-global--warning-color--100);
}
.lv-plugin__table__severity-info::before {
  background-color: var(--pf-v5-global--palette--green-300);
}
.lv-plugin__table__severity-debug::before {
  background-color: var(--pf-v5-global--palette--light-blue-400);
}
.lv-plugin__table__severity-trace::before {
  background-color: var(--pf-v5-global--palette--cyan-200);
}

![image](https://github.com/user-attachments/assets/25abb0a9-6810-46a0-be13-55aa231dffcb)
Figure 1. Example for error. Sort by `Severity > error`. All logs with severity 'error' should be red. 

![image](https://github.com/user-attachments/assets/60a38f04-6882-4519-8f6d-4f52ddd6d654)
Figure 2. Example for trace. Sort by `Severity > trace`. All logs with severity 'trace' should be cyan. 

![image](https://github.com/user-attachments/assets/80d901ca-f6e6-49f7-bb4e-af64325b1ead)
Figure 3. Example for info. Sort by `Severity > info`. All logs with severity 'info' should be green. 

#### Setup:
1. Deploy logging-view-plugin and the necessary logging component. You can use these [configuration files](https://github.com/zhuje/development-tools/tree/main/logging); run the script ./start.sh.
2. The script will create a CLI prompt asking you to choose a data model a) otel b) viaq. Choose 'a' this will configure ClusterLogForwarder to use OpenTelemetry.
3. Then you can access the 'Observe > Logs > Show Resources' button to display the resources circled in Figure 1.


### Unit test 
To run the new unit test: 
```
cd logging-view-plugin/web/src/__tests__
npx jest parse-resource.spec.ts 
```

