### PR TITLE
OU-670: fix: format y series ticks to avoid text overflow

### DIFF
--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -19,6 +19,7 @@ import { TestIds } from '../test-ids';
 import { defaultTimeRange, intervalFromTimeRange, numericTimeRange } from '../time-range';
 import { CenteredContainer } from './centered-container';
 import './logs-metrics.css';
+import { formatValue } from './value-formatter';
 
 const colors = getThemeColors(ChartThemeColor.multiUnordered).line?.colorScale;
 
@@ -216,7 +217,7 @@ export const LogsMetrics: React.FC<LogsMetricsProps> = ({
                 )
               }
             />
-            <ChartAxis dependentAxis showGrid />
+            <ChartAxis dependentAxis showGrid tickFormat={formatValue} />
             <ChartGroup>
               {data.map((series) => (
                 <ChartLine name={series.name} key={series.name} data={series.data} />

--- a/web/src/components/value-formatter.ts
+++ b/web/src/components/value-formatter.ts
@@ -1,0 +1,39 @@
+const toFixed = (value: number): string => {
+  // return value to fixed with decimal places, only if the value is not an integer
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+
+  return value.toFixed(2);
+};
+
+const humanizeNumber = (value: number): string => {
+  // humanize big values, such as 1000 into 1k, 1000000 into 1M, etc.
+  if (value >= 1e12) {
+    return `${toFixed(value / 1e12)}T`;
+  }
+  if (value >= 1e9) {
+    return `${toFixed(value / 1e9)}B`;
+  }
+  if (value >= 1e6) {
+    return `${toFixed(value / 1e6)}M`;
+  }
+  if (value >= 1e3) {
+    return `${toFixed(value / 1e3)}K`;
+  }
+
+  return value.toString();
+};
+
+export const formatValue = (value: string | number): string => {
+  if (typeof value === 'number') {
+    return humanizeNumber(value);
+  } else if (typeof value === 'string') {
+    const num = parseFloat(value);
+    if (!isNaN(num)) {
+      return humanizeNumber(num);
+    }
+  }
+
+  return value;
+};


### PR DESCRIPTION
Humanize y axis ticks to avoid text overflow:

<img width="1175" alt="Screenshot 2025-04-11 at 17 01 02" src="https://github.com/user-attachments/assets/5f74c0ff-b10b-4e62-a5cb-a3d134888258" />
