### PR TITLE
NO-JIRA:  replace react-router and react-router-dom with react-router-dom-compat-v5

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,8 +53,6 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-helmet": "^6.1.0",
-        "react-router": "5.3.x",
-        "react-router-dom": "5.3.x",
         "serve": "^14.2.3",
         "style-loader": "^3.3.1",
         "ts-jest": "^28.0.8",

--- a/web/package.json
+++ b/web/package.json
@@ -65,8 +65,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "^6.1.0",
-    "react-router": "5.3.x",
-    "react-router-dom": "5.3.x",
     "serve": "^14.2.3",
     "style-loader": "^3.3.1",
     "ts-jest": "^28.0.8",

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -2,7 +2,7 @@ import { ResourceLink, RowProps, TableColumn } from '@openshift-console/dynamic-
 import { Split, SplitItem } from '@patternfly/react-core';
 import { ISortBy, SortByDirection, Td, ThProps } from '@patternfly/react-table';
 import React, { useCallback, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom-v5-compat';
 import { DateFormat, dateToFormat } from '../date-utils';
 import {
   Direction,

--- a/web/src/e2e-tests-app.tsx
+++ b/web/src/e2e-tests-app.tsx
@@ -1,7 +1,7 @@
 import '@patternfly/patternfly/patternfly.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter, Link, Route, useHistory, useParams } from 'react-router-dom';
+import { BrowserRouter, Link, Route, useNavigate, useParams } from 'react-router-dom-v5-compat';
 import LogsAlertMetrics from './components/alerts/logs-alerts-metrics';
 import i18n from './i18n';
 import './index.css';
@@ -19,7 +19,7 @@ import { TestIds } from './test-ids';
 
 const DevConsole = () => {
   const { ns: namespace } = useParams<{ ns: string }>();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = React.useState(false);
 
   const onToggle = () => {
@@ -27,7 +27,7 @@ const DevConsole = () => {
   };
 
   const onSelectNamespace = (selectedNamespace: string) => () => {
-    history.push(`/dev-monitoring/ns/${selectedNamespace}/logs`);
+    navigate(`/dev-monitoring/ns/${selectedNamespace}/logs`);
     setIsOpen(false);
   };
 

--- a/web/src/hooks/useQueryParams.ts
+++ b/web/src/hooks/useQueryParams.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 export const useQueryParams = () => {
   const location = useLocation();

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import { filtersFromQuery } from '../attribute-filters';
 import { AttributeList, Filters } from '../components/filters/filter.types';
 import { Direction, TimeRange } from '../logs.types';
@@ -35,7 +35,7 @@ export const useURLState = ({
   attributes,
 }: UseURLStateHook) => {
   const queryParams = useQueryParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
 
   const initialTenant = queryParams.get(TENANT_PARAM_KEY) ?? defaultTenant;
@@ -68,29 +68,29 @@ export const useURLState = ({
 
   const setTenantInURL = (selectedTenant: string) => {
     queryParams.set(TENANT_PARAM_KEY, selectedTenant);
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   const setShowResourcesInURL = (showResources: boolean) => {
     queryParams.set(SHOW_RESOURCES_PARAM_KEY, showResources ? '1' : '0');
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   const setShowStatsInURL = (showStats: boolean) => {
     queryParams.set(SHOW_STATS_PARAM_KEY, showStats ? '1' : '0');
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   const setQueryInURL = (newQuery: string) => {
     const trimmedQuery = newQuery.trim();
     queryParams.set(QUERY_PARAM_KEY, trimmedQuery);
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   const setTimeRangeInURL = (selectedTimeRange: TimeRange) => {
     queryParams.set(TIME_RANGE_START, String(selectedTimeRange.start));
     queryParams.set(TIME_RANGE_END, String(selectedTimeRange.end));
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   const setDirectionInURL = (selectedDirection?: 'forward' | 'backward') => {
@@ -99,7 +99,7 @@ export const useURLState = ({
     } else {
       queryParams.delete(DIRECTION);
     }
-    history.push(`${location.pathname}?${queryParams.toString()}`);
+    navigate(`${location.pathname}?${queryParams.toString()}`);
   };
 
   React.useEffect(() => {

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -11,7 +11,7 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom-v5-compat';
 import { availablePodAttributes, filtersFromQuery, queryFromFilters } from '../attribute-filters';
 import { AttributeList, Filters } from '../components/filters/filter.types';
 import { LogsHistogram } from '../components/logs-histogram';

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -2,7 +2,7 @@ import { Button, Card, CardBody, Flex, Grid, PageSection, Tooltip } from '@patte
 import { SyncAltIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router';
+import { useParams } from 'react-router-dom-v5-compat';
 import {
   availableDevConsoleAttributes,
   initialAvailableAttributes,


### PR DESCRIPTION
### Context 
remove react-router and react-router-dom to be replaced by react-router-dom-compat-v5 for transition to react-router v6

### Related JIRA from /openshift/console changes 
https://github.com/openshift/console/pull/14957

### Threads  
Slack #observability-ui-interal thread 
https://redhat-internal.slack.com/archives/C03EPFR2BAR/p1744392852882399

Slack #announce-console-plugins
https://redhat-internal.slack.com/archives/C032NLNEE8G/p1744391666020899