### PR TITLE
OU-731: feat: add otel for quering support and plugin configuration

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ type PluginConfig struct {
 	AlertingRuleNamespaceLabelKey   string        `json:"alertingRuleNamespaceLabelKey,omitempty" yaml:"alertingRuleNamespaceLabelKey,omitempty"`
 	Timeout                         time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	LogsLimit                       int           `json:"logsLimit,omitempty" yaml:"logsLimit,omitempty"`
+	Schema                          string        `json:"schema,omitempty" yaml:"schema,omitempty"`
 }
 
 func (pluginConfig *PluginConfig) MarshalJSON() ([]byte, error) {

--- a/web/cypress/integration/logs-dev-page.cy.ts
+++ b/web/cypress/integration/logs-dev-page.cy.ts
@@ -160,9 +160,7 @@ describe('Logs Dev Page', () => {
     cy.wait('@queryRangeStreams').then(({ request }) => {
       const url = new URL(request.url);
       const query = url.searchParams.get('query');
-      expect(query).to.equal(
-        '{ log_type="application", kubernetes_namespace_name="my-namespace" } | json',
-      );
+      expect(query).to.equal('{ kubernetes_namespace_name="my-namespace" } | json');
     });
   });
 
@@ -186,9 +184,7 @@ describe('Logs Dev Page', () => {
     cy.wait('@queryRangeStreams').then(({ request }) => {
       const url = new URL(request.url);
       const query = url.searchParams.get('query');
-      expect(query).to.equal(
-        '{ log_type="application", kubernetes_namespace_name="my-namespace" } | json',
-      );
+      expect(query).to.equal('{ kubernetes_namespace_name="my-namespace" } | json');
     });
 
     cy.getByTestId(TestIds.NamespaceToggle).click();
@@ -197,9 +193,7 @@ describe('Logs Dev Page', () => {
     cy.wait('@queryRangeStreams').then(({ request }) => {
       const url = new URL(request.url);
       const query = url.searchParams.get('query');
-      expect(query).to.equal(
-        '{ log_type="application", kubernetes_namespace_name="my-namespace-two" } | json',
-      );
+      expect(query).to.equal('{ kubernetes_namespace_name="my-namespace-two" } | json');
     });
   });
 
@@ -231,9 +225,7 @@ describe('Logs Dev Page', () => {
     cy.wait('@queryRangeStreams').then(({ request }) => {
       const url = new URL(request.url);
       const query = url.searchParams.get('query');
-      expect(query).to.equal(
-        '{ log_type="application", kubernetes_namespace_name="my-namespace" } | json',
-      );
+      expect(query).to.equal('{ kubernetes_namespace_name="my-namespace" } | json');
     });
 
     cy.getByTestId(TestIds.NamespaceToggle).click();
@@ -246,9 +238,7 @@ describe('Logs Dev Page', () => {
         '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure/loki/api/v1/query_range',
       );
       const query = url.searchParams.get('query');
-      expect(query).to.equal(
-        '{ log_type="infrastructure", kubernetes_namespace_name="openshift-cluster-version" } | json',
-      );
+      expect(query).to.equal('{ kubernetes_namespace_name="openshift-cluster-version" } | json');
     });
   });
 

--- a/web/cypress/integration/logs-page.cy.ts
+++ b/web/cypress/integration/logs-page.cy.ts
@@ -410,7 +410,7 @@ describe('Logs Page', () => {
         .invoke('val')
         .should(
           'equal',
-          '{ log_type="application", kubernetes_namespace_name="gitops" } |= `line filter` | json | level=~"error|err|eror|info|inf|information|notice"',
+          '{ kubernetes_namespace_name="gitops" } |= `line filter` | json | level=~"error|err|eror|info|inf|information|notice"',
         );
     });
 
@@ -682,7 +682,7 @@ describe('Logs Page', () => {
         .invoke('val')
         .should(
           'equal',
-          '{ log_type="application", kubernetes_container_name="operator", kubernetes_pod_name="my-pod-2" } | json',
+          '{ kubernetes_container_name="operator", kubernetes_pod_name="my-pod-2" } | json',
         );
     });
 

--- a/web/locales/en/plugin__logging-view-plugin.json
+++ b/web/locales/en/plugin__logging-view-plugin.json
@@ -24,7 +24,7 @@
   "No datapoints found": "No datapoints found",
   "No data": "No data",
   "Invalid data": "Invalid data",
-  "Invalid log stream selector. Please select a namespace, pod or container as filter, or add a log stream selector like: ": "Invalid log stream selector. Please select a namespace, pod or container as filter, or add a log stream selector like: ",
+  "Invalid log stream selector. Please select a namespace, pod or container as filter.": "Invalid log stream selector. Please select a namespace, pod or container as filter.",
   "Show Resources": "Show Resources",
   "Hide Resources": "Hide Resources",
   "Show Stats": "Show Stats",

--- a/web/src/__tests__/loki-client-spec.ts
+++ b/web/src/__tests__/loki-client-spec.ts
@@ -1,10 +1,16 @@
+import { SchemaConfig } from '../logs.types';
 import { getFetchConfig } from '../loki-client';
 
 describe('Loki Client', () => {
   it('should generate a valid config', () => {
     [
       {
-        config: { config: undefined, tenant: 'application', logsLimit: 100 },
+        config: {
+          config: undefined,
+          tenant: 'application',
+          logsLimit: 100,
+          schema: SchemaConfig.viaq,
+        },
         expectedFetchConfig: {
           endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application',
           requestInit: { timeout: undefined },
@@ -12,7 +18,7 @@ describe('Loki Client', () => {
       },
       {
         config: {
-          config: { useTenantInHeader: true, logsLimit: 100 },
+          config: { useTenantInHeader: true, logsLimit: 100, schema: SchemaConfig.viaq },
           tenant: 'application',
         },
         expectedFetchConfig: {
@@ -22,7 +28,7 @@ describe('Loki Client', () => {
       },
       {
         config: {
-          config: { useTenantInHeader: false, logsLimit: 100 },
+          config: { useTenantInHeader: false, logsLimit: 100, schema: SchemaConfig.viaq },
           tenant: 'infrastructure',
         },
         expectedFetchConfig: {
@@ -32,7 +38,12 @@ describe('Loki Client', () => {
       },
       {
         config: {
-          config: { useTenantInHeader: false, logsLimit: 100, timeout: 2 },
+          config: {
+            useTenantInHeader: false,
+            logsLimit: 100,
+            timeout: 2,
+            schema: SchemaConfig.viaq,
+          },
           tenant: 'infrastructure',
         },
         expectedFetchConfig: {

--- a/web/src/cancellable-fetch.ts
+++ b/web/src/cancellable-fetch.ts
@@ -46,8 +46,8 @@ export const cancellableFetch = <T>(
   const abortController = new AbortController();
   const abort = () => abortController.abort();
 
-  const fetchPromise = () =>
-    fetch(url, {
+  const fetchPromise = async () => {
+    const response = await fetch(url, {
       ...init,
       headers: {
         ...init?.headers,
@@ -55,13 +55,14 @@ export const cancellableFetch = <T>(
         ...(init?.method === 'POST' ? { 'X-CSRFToken': getCSRFToken() } : {}),
       },
       signal: abortController.signal,
-    }).then(async (response) => {
-      if (!response.ok) {
-        const text = await response.text();
-        throw new FetchError(text, response.status);
-      }
-      return response.json();
     });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new FetchError(text, response.status);
+    }
+    return response.json();
+  };
 
   const timeout = init?.timeout ?? 30 * 1000;
 

--- a/web/src/components/alerts/logs-alerts-metrics.tsx
+++ b/web/src/components/alerts/logs-alerts-metrics.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LogsConfigProvider, useLogsConfig } from '../../hooks/LogsConfigProvider';
 import { useLogs } from '../../hooks/useLogs';
 import { Rule, TimeRange } from '../../logs.types';
+import { getSchema } from '../../value-utils';
 import { LogsMetrics } from '../logs-metrics';
 import { TimeRangeDropdown } from '../time-range-dropdown';
 
@@ -13,14 +15,15 @@ const LOKI_TENANT_LABEL_KEY = 'tenantId';
 
 const LogsAlertMetrics: React.FC<LogsAlertMetricsProps> = ({ rule }) => {
   const { t } = useTranslation('plugin__logging-view-plugin');
-  const { getLogs, logsData, logsError, isLoadingLogsData, config } = useLogs();
+  const { getLogs, logsData, logsError, isLoadingLogsData } = useLogs();
+  const { config } = useLogsConfig();
 
   const tenant = rule?.labels?.[config.alertingRuleTenantLabelKey ?? LOKI_TENANT_LABEL_KEY];
   const [timeRange, setTimeRange] = React.useState<TimeRange | undefined>();
 
   useEffect(() => {
     if (rule?.query && tenant) {
-      getLogs({ query: rule.query, timeRange, tenant });
+      getLogs({ query: rule.query, timeRange, tenant, schema: getSchema(config.schema) });
     }
   }, [rule?.query, timeRange]);
 
@@ -47,4 +50,12 @@ const LogsAlertMetrics: React.FC<LogsAlertMetricsProps> = ({ rule }) => {
   );
 };
 
-export default LogsAlertMetrics;
+const LogsAlertMetricsWrapper: React.FC<LogsAlertMetricsProps> = (props) => {
+  return (
+    <LogsConfigProvider>
+      <LogsAlertMetrics {...props} />
+    </LogsConfigProvider>
+  );
+};
+
+export default LogsAlertMetricsWrapper;

--- a/web/src/components/filters/attribute-filter.tsx
+++ b/web/src/components/filters/attribute-filter.tsx
@@ -11,7 +11,7 @@ import {
   ToolbarGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from '../../hooks/useDebounce';
 import { TestIds } from '../../test-ids';
@@ -57,6 +57,12 @@ export const AttributeFilter: React.FC<AttributeFilterProps> = ({
       setTextInputValue(initialText ?? '');
     }
   }, [textAttribute, filters]);
+
+  useEffect(() => {
+    if (!selectedAttributeId) {
+      setSelectedAttributeId(attributeList[0]?.id);
+    }
+  }, [attributeList]);
 
   const handleAttributeSelect = (
     _: React.MouseEvent<Element, MouseEvent> | undefined,

--- a/web/src/components/filters/attribute-value-data.tsx
+++ b/web/src/components/filters/attribute-value-data.tsx
@@ -19,9 +19,9 @@ export const useAttributeValueData = (attribute: Attribute): UseAttributeValueDa
       setAttributeError(undefined);
       if (attribute.options) {
         if (Array.isArray(attribute.options)) {
+          setAttributeLoading(false);
           setAttributeOptions(attribute.options);
         } else {
-          setAttributeLoading(true);
           attribute
             .options(searchQuery)
             .then((asyncOptions) => {

--- a/web/src/components/logs-query-input.tsx
+++ b/web/src/components/logs-query-input.tsx
@@ -59,9 +59,9 @@ export const LogsQueryInput: React.FC<LogsQueryInputProps> = ({
               variant="danger"
               title={
                 !isValid
-                  ? `${t(
-                      'Invalid log stream selector. Please select a namespace, pod or container as filter, or add a log stream selector like: ',
-                    )} { log_type =~ ".+" } | json`
+                  ? t(
+                      'Invalid log stream selector. Please select a namespace, pod or container as filter.',
+                    )
                   : invalidQueryErrorMessage
               }
               aria-live="polite"

--- a/web/src/components/logs-toolbar.tsx
+++ b/web/src/components/logs-toolbar.tsx
@@ -16,6 +16,8 @@ import {
 } from '@patternfly/react-core';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLogsConfig } from '../hooks/LogsConfigProvider';
+import { Schema, SchemaConfig } from '../logs.types';
 import { Severity, severityFromString } from '../severity';
 import { TestIds } from '../test-ids';
 import { notUndefined } from '../value-utils';
@@ -23,13 +25,14 @@ import { ExecuteQueryButton } from './execute-query-button';
 import { ExecuteVolumeButton } from './execute-volume-button';
 import { AttributeFilter } from './filters/attribute-filter';
 import { AttributeList, Filters } from './filters/filter.types';
+import { isOption } from './filters/filters-from-params';
 import { LogsQueryInput } from './logs-query-input';
 import './logs-toolbar.css';
+import { SchemaDropdown } from './schema-dropdown';
 import { Spacer } from './spacer';
 import { TenantDropdown } from './tenant-dropdown';
 import { ToggleButton } from './toggle-button';
 import { TogglePlay } from './toggle-play';
-import { isOption } from './filters/filters-from-params';
 
 interface LogsToolbarProps {
   query: string;
@@ -39,6 +42,7 @@ interface LogsToolbarProps {
   invalidQueryErrorMessage?: string | null;
   tenant?: string;
   onTenantSelect?: (tenant: string) => void;
+  onSchemaSelect?: (schema: Schema) => void;
   enableStreaming?: boolean;
   isStreaming?: boolean;
   severityFilter?: Set<Severity>;
@@ -54,6 +58,7 @@ interface LogsToolbarProps {
   filters?: Filters;
   attributeList?: AttributeList;
   onDownloadCSV?: () => void;
+  schema: Schema;
 }
 
 const availableSeverityFilters: Array<Severity> = [
@@ -74,6 +79,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   invalidQueryErrorMessage,
   tenant = 'application',
   onTenantSelect,
+  onSchemaSelect,
   onStreamingToggle,
   onShowResourcesToggle,
   onDownloadCSV,
@@ -87,11 +93,22 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   filters,
   onFiltersChange,
   attributeList,
+  schema,
 }) => {
   const { t } = useTranslation('plugin__logging-view-plugin');
 
   const [isSeverityExpanded, setIsSeverityExpanded] = React.useState(false);
   const [isQueryShown, setIsQueryShown] = React.useState(false);
+  const [isSchemaShown, setIsSchemaShown] = React.useState(false);
+
+  const { config } = useLogsConfig();
+
+  React.useEffect(() => {
+    if (config?.schema === SchemaConfig.select) {
+      setIsSchemaShown(true);
+    }
+  }, [config?.schema]);
+
   const severityFilter: Set<Severity> = filters?.severity
     ? new Set(Array.from(filters?.severity).map(severityFromString).filter(notUndefined))
     : new Set();
@@ -164,6 +181,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             onFiltersChange={onFiltersChange}
           />
         )}
+
         <ToolbarGroup>
           <ToolbarFilter
             chips={severityFilterArray}
@@ -208,6 +226,12 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
           </ToolbarGroup>
         )}
 
+        {isSchemaShown && (
+          <ToolbarGroup>
+            <SchemaDropdown onSchemaSelected={onSchemaSelect} schema={schema} />
+          </ToolbarGroup>
+        )}
+
         <ToolbarGroup>
           <ToggleButton
             isToggled={showResources}
@@ -215,9 +239,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
             untoggledText={t('Show Resources')}
             toggledText={t('Hide Resources')}
           />
-        </ToolbarGroup>
 
-        <ToolbarGroup>
           <ToggleButton
             isToggled={showStats}
             onToggle={onShowStatsToggle}
@@ -227,41 +249,43 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
           />
         </ToolbarGroup>
 
-        {onDownloadCSV && (
-          <ToolbarGroup>
-            <Button variant="secondary" isInline onClick={onDownloadCSV}>
-              {t('Export as CSV')}
-            </Button>
-          </ToolbarGroup>
-        )}
-
         <ToolbarGroup>
-          <ExecuteVolumeButton onClick={onVolumeRun} isDisabled={isDisabled} />
-        </ToolbarGroup>
-
-        {!isQueryShown && (
-          <>
+          {onDownloadCSV && (
             <ToolbarGroup>
-              <ExecuteQueryButton onClick={onQueryRun} isDisabled={isDisabled} />
+              <Button variant="secondary" isInline onClick={onDownloadCSV}>
+                {t('Export as CSV')}
+              </Button>
             </ToolbarGroup>
-            {invalidQueryErrorMessage && (
+          )}
+
+          <ToolbarGroup>
+            <ExecuteVolumeButton onClick={onVolumeRun} isDisabled={isDisabled} />
+          </ToolbarGroup>
+
+          {!isQueryShown && (
+            <>
               <ToolbarGroup>
-                <Alert variant="danger" isInline isPlain title={invalidQueryErrorMessage} />
+                <ExecuteQueryButton onClick={onQueryRun} isDisabled={isDisabled} />
               </ToolbarGroup>
-            )}
-          </>
-        )}
+              {invalidQueryErrorMessage && (
+                <ToolbarGroup>
+                  <Alert variant="danger" isInline isPlain title={invalidQueryErrorMessage} />
+                </ToolbarGroup>
+              )}
+            </>
+          )}
 
-        <Spacer />
+          <Spacer />
 
-        <ToolbarGroup>
-          <ToggleButton
-            isToggled={isQueryShown}
-            onToggle={setIsQueryShown}
-            untoggledText={t('Show Query')}
-            toggledText={t('Hide Query')}
-            data-test={TestIds.ShowQueryToggle}
-          />
+          <ToolbarGroup>
+            <ToggleButton
+              isToggled={isQueryShown}
+              onToggle={setIsQueryShown}
+              untoggledText={t('Show Query')}
+              toggledText={t('Hide Query')}
+              data-test={TestIds.ShowQueryToggle}
+            />
+          </ToolbarGroup>
         </ToolbarGroup>
 
         {enableStreaming && (

--- a/web/src/components/schema-dropdown.tsx
+++ b/web/src/components/schema-dropdown.tsx
@@ -1,0 +1,63 @@
+import {
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Schema } from '../logs.types';
+import { TestIds } from '../test-ids';
+
+type SchemaDropdownProps = {
+  onSchemaSelected: ((schema: Schema) => void) | undefined;
+  schema: Schema;
+};
+
+export const SchemaDropdown: React.FC<SchemaDropdownProps> = ({ onSchemaSelected, schema }) => {
+  const { t } = useTranslation('plugin__logging-view-plugin');
+
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onToggle = () => setIsOpen(!isOpen);
+  const onSelect = (
+    _: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    if (value != schema) {
+      onSchemaSelected?.(value as Schema);
+    }
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggle}
+      isExpanded={isOpen}
+      data-test={TestIds.SchemaToggle}
+    >
+      {schema}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id="logging-view-schema-dropdown"
+      isOpen={isOpen}
+      onSelect={onSelect}
+      placeholder={t('Select a Schema')}
+      toggle={toggle}
+    >
+      <SelectList>
+        <SelectOption key={'otel'} value={Schema.otel} isSelected={schema === Schema.otel}>
+          otel
+        </SelectOption>
+        <SelectOption key={'viaq'} value={Schema.viaq} isSelected={schema === Schema.viaq}>
+          viaQ
+        </SelectOption>
+      </SelectList>
+    </Select>
+  );
+};

--- a/web/src/getAlertingRules.ts
+++ b/web/src/getAlertingRules.ts
@@ -1,3 +1,4 @@
+import { getConfig } from './backend-client';
 import { RulesResponse } from './logs.types';
 import { getRules } from './loki-client';
 import { namespaceBelongsToInfrastructureTenant } from './value-utils';
@@ -22,13 +23,15 @@ export const getAlertingRules = async (tenants: Array<string>, namespace?: strin
     return null;
   }
 
+  const config = await getConfig();
+
   const rulesResponses = await Promise.allSettled(
     tenants.map((tenant) => {
       if (abortControllers.has(tenant)) {
         abortControllers.get(tenant)?.();
       }
 
-      const { abort, request } = getRules({ tenant, namespace });
+      const { abort, request } = getRules({ tenant, namespace, config });
       abortControllers.set(tenant, abort);
 
       return request();

--- a/web/src/hooks/LogsConfigProvider.tsx
+++ b/web/src/hooks/LogsConfigProvider.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { defaultConfig, getConfig } from '../backend-client';
+import { Config } from '../logs.types';
+
+interface LogsContextType {
+  config: Config;
+  fetchConfig: () => Promise<Config>;
+}
+
+export const LogsContext = createContext<LogsContextType | undefined>(undefined);
+
+export const LogsConfigProvider: React.FC<{ children?: React.ReactNode | undefined }> = ({
+  children,
+}) => {
+  const [config, setConfig] = useState<Config>(defaultConfig);
+  const [configLoaded, setConfigLoaded] = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      if (!configLoaded) {
+        const configData = await getConfig();
+        const mergedConfig = { ...defaultConfig, ...configData };
+        setConfigLoaded(true);
+        setConfig(mergedConfig);
+
+        return mergedConfig;
+      }
+
+      return config;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error fetching logging plugin configuration', error);
+      setConfig(defaultConfig);
+      return defaultConfig;
+    }
+  }, [config]);
+
+  return <LogsContext.Provider value={{ config, fetchConfig }}>{children}</LogsContext.Provider>;
+};
+
+export const useLogsConfig = (): LogsContextType => {
+  const context = useContext(LogsContext);
+
+  if (context === undefined) {
+    throw new Error('useLogsConfig must be used within a LogsConfigProvider');
+  }
+
+  useEffect(() => {
+    context.fetchConfig();
+  }, []);
+
+  return context;
+};

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -1,15 +1,27 @@
-import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
-import { filtersFromQuery } from '../attribute-filters';
+import React, { DependencyList } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { filtersFromQuery, queryFromFilters } from '../attribute-filters';
 import { AttributeList, Filters } from '../components/filters/filter.types';
-import { Direction, TimeRange } from '../logs.types';
+import { Config, Direction, Schema, TimeRange } from '../logs.types';
+import { ResourceLabel, ResourceToStreamLabels } from '../parse-resources';
 import { intervalFromTimeRange } from '../time-range';
+import { getSchema } from '../value-utils';
+import { useLogsConfig } from './LogsConfigProvider';
 import { useQueryParams } from './useQueryParams';
 
 interface UseURLStateHook {
-  defaultQuery?: string;
   defaultTenant?: string;
-  attributes: AttributeList;
+  getDefaultQuery?({ tenant, schema }: { tenant: string; schema: Schema }): string;
+  getAttributes?: ({
+    tenant,
+    config,
+    schema,
+  }: {
+    tenant: string;
+    config: Config;
+    schema: Schema;
+  }) => AttributeList | undefined;
+  attributesDependencies?: DependencyList;
 }
 
 const QUERY_PARAM_KEY = 'q';
@@ -17,30 +29,50 @@ const TIME_RANGE_START = 'start';
 const TIME_RANGE_END = 'end';
 const DIRECTION = 'direction';
 const TENANT_PARAM_KEY = 'tenant';
+const SCHEMA_PARAM_KEY = 'schema';
 const SHOW_RESOURCES_PARAM_KEY = 'showResources';
 const SHOW_STATS_PARAM_KEY = 'showStats';
 
-const DEFAULT_TENANT = 'application';
+export const DEFAULT_TENANT = 'application';
 const DEFAULT_SHOW_RESOURCES = '0';
 const DEFAULT_SHOW_STATS = '0';
-export const defaultQueryFromTenant = (tenant: string = DEFAULT_TENANT) =>
-  `{ log_type="${tenant}" } | json`;
+
+export const defaultQueryFromTenant = ({
+  tenant = DEFAULT_TENANT,
+  schema,
+}: {
+  tenant?: string;
+  schema: Schema;
+}) => {
+  const logType = ResourceToStreamLabels[ResourceLabel.LogType];
+  if (schema === Schema.otel) {
+    return `{ ${logType.otel}="${tenant}" } `;
+  }
+  return `{ ${logType.viaq}="${tenant}" } | json`;
+};
 
 const getDirectionValue = (value?: string | null): Direction =>
   value !== null ? (value === 'forward' ? 'forward' : 'backward') : 'backward';
 
 export const useURLState = ({
-  defaultQuery,
   defaultTenant = DEFAULT_TENANT,
-  attributes,
+  getDefaultQuery,
+  getAttributes,
+  attributesDependencies,
 }: UseURLStateHook) => {
   const queryParams = useQueryParams();
   const navigate = useNavigate();
   const location = useLocation();
+  const { config } = useLogsConfig();
 
   const initialTenant = queryParams.get(TENANT_PARAM_KEY) ?? defaultTenant;
+  const initialSchema: Schema = getSchema(queryParams.get(SCHEMA_PARAM_KEY) ?? config?.schema);
+
   const initialQuery =
-    queryParams.get(QUERY_PARAM_KEY) ?? defaultQuery ?? defaultQueryFromTenant(initialTenant);
+    queryParams.get(QUERY_PARAM_KEY) ??
+    getDefaultQuery?.({ tenant: initialTenant, schema: initialSchema }) ??
+    defaultQueryFromTenant({ tenant: initialTenant, schema: initialSchema });
+
   const initialTimeRangeStart = queryParams.get(TIME_RANGE_START);
   const initialTimeRangeEnd = queryParams.get(TIME_RANGE_END);
   const initialDirection = queryParams.get(DIRECTION);
@@ -51,9 +83,15 @@ export const useURLState = ({
 
   const [query, setQuery] = React.useState(initialQuery);
   const [tenant, setTenant] = React.useState(initialTenant);
-  const [filters, setFilters] = React.useState<Filters | undefined>(
-    filtersFromQuery({ query: initialQuery, attributes }),
+  const [schema, setSchema] = React.useState(initialSchema);
+  const attributes = React.useMemo<AttributeList>(
+    () => (getAttributes ? getAttributes({ tenant, config, schema }) ?? [] : []),
+    [tenant, config, schema, ...(attributesDependencies || [])],
   );
+  const [filters, setFilters] = React.useState<Filters | undefined>(
+    filtersFromQuery({ query: initialQuery, attributes, schema }),
+  );
+
   const [areResourcesShown, setAreResourcesShown] = React.useState<boolean>(initialResorcesShown);
   const [areStatsShown, setAreStatsShown] = React.useState<boolean>(intitalStatsShown);
   const [direction, setDirection] = React.useState<Direction>(getDirectionValue(initialDirection));
@@ -69,6 +107,28 @@ export const useURLState = ({
   const setTenantInURL = (selectedTenant: string) => {
     queryParams.set(TENANT_PARAM_KEY, selectedTenant);
     navigate(`${location.pathname}?${queryParams.toString()}`);
+  };
+
+  const setSchemaInURL = (selectedSchema: Schema) => {
+    if (selectedSchema) {
+      queryParams.set(SCHEMA_PARAM_KEY, selectedSchema as string);
+
+      // re create query based on current filters and new schema
+      const newQuery = queryFromFilters({
+        existingQuery: '',
+        filters,
+        attributes,
+        tenant,
+        schema: selectedSchema,
+        addJSONParser: true,
+      });
+      queryParams.set(QUERY_PARAM_KEY, newQuery);
+
+      navigate(`${location.pathname}?${queryParams.toString()}`);
+    } else {
+      queryParams.delete(SCHEMA_PARAM_KEY);
+      navigate(`${location.pathname}?${queryParams.toString()}`);
+    }
   };
 
   const setShowResourcesInURL = (showResources: boolean) => {
@@ -103,6 +163,7 @@ export const useURLState = ({
   };
 
   React.useEffect(() => {
+    const schemaValue = getSchema(queryParams.get(SCHEMA_PARAM_KEY) ?? config?.schema);
     const queryValue = queryParams.get(QUERY_PARAM_KEY) ?? initialQuery;
     const tenantValue = queryParams.get(TENANT_PARAM_KEY) ?? DEFAULT_TENANT;
     const showResourcesValue = queryParams.get(SHOW_RESOURCES_PARAM_KEY) ?? DEFAULT_SHOW_RESOURCES;
@@ -113,10 +174,13 @@ export const useURLState = ({
 
     setQuery(queryValue.trim());
     setTenant(tenantValue);
+    setSchema(schemaValue);
     setDirection(getDirectionValue(directionValue));
     setAreResourcesShown(showResourcesValue === '1');
     setAreStatsShown(showStatsValue === '1');
-    setFilters(filtersFromQuery({ query: queryValue, attributes }));
+    setFilters(
+      filtersFromQuery({ query: queryValue, attributes: attributes, schema: schemaValue }),
+    );
     setTimeRange((prevTimeRange) => {
       if (!timeRangeStartValue || !timeRangeEndValue) {
         return undefined;
@@ -134,13 +198,16 @@ export const useURLState = ({
         end: timeRangeEndValue,
       };
     });
-  }, [queryParams]);
+  }, [queryParams, attributes]);
 
   return {
+    initialQuery,
     query,
     setQueryInURL,
     tenant,
     setTenantInURL,
+    schema,
+    setSchemaInURL,
     areResourcesShown,
     setShowResourcesInURL,
     areStatsShown,
@@ -150,6 +217,7 @@ export const useURLState = ({
     timeRange,
     setTimeRangeInURL,
     setDirectionInURL,
+    attributes,
     direction,
     interval: timeRange ? intervalFromTimeRange(timeRange) : undefined,
   };

--- a/web/src/logs.types.ts
+++ b/web/src/logs.types.ts
@@ -1,3 +1,15 @@
+export enum SchemaConfig {
+  viaq = 'viaq',
+  otel = 'otel',
+  select = 'select', // allows dropdown to appear to select either viaq of otel
+}
+
+export enum Schema {
+  viaq = 'viaq',
+  otel = 'otel',
+}
+export const DEFAULT_SCHEMA = Schema.viaq;
+
 export type Config = {
   useTenantInHeader?: boolean;
   isStreamingEnabledInDefaultPage?: boolean;
@@ -5,6 +17,7 @@ export type Config = {
   alertingRuleNamespaceLabelKey?: string;
   timeout?: number;
   logsLimit: number;
+  schema: SchemaConfig;
 };
 
 export type MetricValue = Array<number | string>;

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -13,21 +13,23 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import { availablePodAttributes, filtersFromQuery, queryFromFilters } from '../attribute-filters';
-import { AttributeList, Filters } from '../components/filters/filter.types';
+import { CenteredContainer } from '../components/centered-container';
+import { Filters } from '../components/filters/filter.types';
 import { LogsHistogram } from '../components/logs-histogram';
+import { LogsMetrics } from '../components/logs-metrics';
 import { LogsTable } from '../components/logs-table';
 import { LogsToolbar } from '../components/logs-toolbar';
 import { RefreshIntervalDropdown } from '../components/refresh-interval-dropdown';
 import { TimeRangeDropdown } from '../components/time-range-dropdown';
 import { ToggleHistogramButton } from '../components/toggle-histogram-button';
+import { downloadCSV } from '../download-csv';
+import { LogsConfigProvider } from '../hooks/LogsConfigProvider';
 import { useLogs } from '../hooks/useLogs';
 import { useURLState } from '../hooks/useURLState';
-import { Direction, isMatrixResult } from '../logs.types';
+import { Direction, isMatrixResult, Schema } from '../logs.types';
+import { getStreamLabelsFromSchema, ResourceLabel } from '../parse-resources';
 import { TestIds } from '../test-ids';
 import { getInitialTenantFromNamespace } from '../value-utils';
-import { CenteredContainer } from '../components/centered-container';
-import { LogsMetrics } from '../components/logs-metrics';
-import { downloadCSV } from '../download-csv';
 
 /*
 This comment creates an entry in the translations catalogue for console extensions
@@ -51,7 +53,6 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
     useParams<{ name: string; ns: string }>();
   const namespace = namespaceFromParams || namespaceFromProps;
   const podname = podnameFromParams || podNameFromProps;
-  const defaultQuery = `{ kubernetes_pod_name = "${podname}" } | json`;
   const [isHistogramVisible, setIsHistogramVisible] = React.useState(false);
 
   const {
@@ -73,17 +74,14 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
     histogramData,
     isLoadingHistogramData,
     histogramError,
-    config,
   } = useLogs();
 
-  const attributesForPod: AttributeList = React.useMemo(
-    () => (namespace && podname ? availablePodAttributes(namespace, podname, config) : []),
-    [podname, config],
-  );
-
   const {
+    initialQuery,
     query,
     setQueryInURL,
+    schema,
+    setSchemaInURL,
     areResourcesShown,
     setShowResourcesInURL,
     areStatsShown,
@@ -95,20 +93,32 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
     timeRange,
     direction,
     setDirectionInURL,
+    attributes,
   } = useURLState({
-    defaultQuery,
-    attributes: attributesForPod,
+    getDefaultQuery: ({ schema: s }) => {
+      const labelMatchers = getStreamLabelsFromSchema(s);
+      const podLabel = labelMatchers[ResourceLabel.Pod];
+
+      return `{ ${podLabel} = "${podname}" }${s == Schema.viaq ? ' | json' : ''}`;
+    },
+    getAttributes: ({ config: c, schema: s }) => {
+      if (namespace && podname) {
+        return availablePodAttributes(namespace, podname, c, s);
+      }
+    },
+    attributesDependencies: [namespace, podname],
   });
+
   const initialTenant = getInitialTenantFromNamespace(namespace);
   const tenant = React.useRef(initialTenant);
 
   const handleToggleStreaming = () => {
-    toggleStreaming({ query });
+    toggleStreaming({ query, schema });
   };
 
   const handleLoadMoreData = (lastTimestamp: number) => {
     if (!isLoadingMoreLogsData) {
-      getMoreLogs({ lastTimestamp, query, namespace, direction });
+      getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
     }
   };
 
@@ -117,27 +127,28 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
   };
 
   const runQuery = () => {
-    getLogs({ query, tenant: tenant.current, namespace, timeRange, direction });
+    getLogs({ query, tenant: tenant.current, namespace, timeRange, direction, schema });
 
     if (isHistogramVisible) {
-      getHistogram({ query, tenant: tenant.current, namespace, timeRange });
+      getHistogram({ query, tenant: tenant.current, namespace, timeRange, schema });
     }
   };
 
   const runVolume = () => {
-    getVolume({ query, tenant: tenant.current, namespace, timeRange });
+    getVolume({ query, tenant: tenant.current, namespace, timeRange, schema });
   };
 
   const handleFiltersChange = (selectedFilters?: Filters) => {
     setFilters(selectedFilters);
 
     if (!selectedFilters || Object.keys(selectedFilters).length === 0) {
-      setQueryInURL(defaultQuery);
+      setQueryInURL(initialQuery);
     } else {
       const updatedQuery = queryFromFilters({
         existingQuery: query,
         filters: selectedFilters,
-        attributes: attributesForPod,
+        attributes,
+        schema,
       });
       setQueryInURL(updatedQuery);
     }
@@ -148,7 +159,8 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
 
     const updatedFilters = filtersFromQuery({
       query: queryFromInput,
-      attributes: attributesForPod,
+      attributes,
+      schema,
     });
 
     setFilters(updatedFilters);
@@ -226,10 +238,12 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
           enableStreaming
           enableTenantDropdown={false}
           isDisabled={isQueryEmpty}
-          attributeList={attributesForPod}
+          attributeList={attributes}
           filters={filters}
           onFiltersChange={handleFiltersChange}
           onDownloadCSV={() => downloadCSV(logsData)}
+          schema={schema}
+          onSchemaSelect={setSchemaInURL}
         />
 
         {isLoadingLogsData ? (
@@ -280,4 +294,12 @@ const LogsDetailPage: React.FC<LogsDetailPageProps> = ({
   );
 };
 
-export default LogsDetailPage;
+const LogsDetailPageWrapper: React.FC<LogsDetailPageProps> = (props) => {
+  return (
+    <LogsConfigProvider>
+      <LogsDetailPage {...props} />
+    </LogsConfigProvider>
+  );
+};
+
+export default LogsDetailPageWrapper;

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -5,8 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
 import {
   availableDevConsoleAttributes,
-  initialAvailableAttributes,
   filtersFromQuery,
+  initialAvailableAttributes,
   queryFromFilters,
 } from '../attribute-filters';
 import { CenteredContainer } from '../components/centered-container';
@@ -18,12 +18,13 @@ import { LogsToolbar } from '../components/logs-toolbar';
 import { RefreshIntervalDropdown } from '../components/refresh-interval-dropdown';
 import { TimeRangeDropdown } from '../components/time-range-dropdown';
 import { ToggleHistogramButton } from '../components/toggle-histogram-button';
+import { downloadCSV } from '../download-csv';
+import { LogsConfigProvider, useLogsConfig } from '../hooks/LogsConfigProvider';
 import { useLogs } from '../hooks/useLogs';
 import { defaultQueryFromTenant, useURLState } from '../hooks/useURLState';
 import { Direction, isMatrixResult } from '../logs.types';
 import { TestIds } from '../test-ids';
 import { getInitialTenantFromNamespace } from '../value-utils';
-import { downloadCSV } from '../download-csv';
 
 /*
 This comment creates an entry in the translations catalogue for console extensions
@@ -43,21 +44,7 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
   const [isHistogramVisible, setIsHistogramVisible] = React.useState(false);
   let tenant = getInitialTenantFromNamespace(namespace);
 
-  const {
-    query,
-    setQueryInURL,
-    areResourcesShown,
-    setShowResourcesInURL,
-    areStatsShown,
-    setShowStatsInURL,
-    filters,
-    setFilters,
-    setTimeRangeInURL,
-    timeRange,
-    interval,
-    direction,
-    setDirectionInURL,
-  } = useURLState({ attributes: initialAvailableAttributes, defaultTenant: tenant });
+  const { config } = useLogsConfig();
 
   const {
     histogramData,
@@ -78,16 +65,39 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
     hasMoreLogsData,
     getHistogram,
     toggleStreaming,
-    config,
   } = useLogs();
 
+  const {
+    query,
+    setQueryInURL,
+    schema,
+    setSchemaInURL,
+    areResourcesShown,
+    setShowResourcesInURL,
+    areStatsShown,
+    setShowStatsInURL,
+    filters,
+    setFilters,
+    setTimeRangeInURL,
+    timeRange,
+    interval,
+    direction,
+    setDirectionInURL,
+    attributes,
+  } = useURLState({
+    defaultTenant: tenant,
+    getAttributes: ({ config: c, schema: s }) =>
+      availableDevConsoleAttributes(getInitialTenantFromNamespace(namespace), c, s),
+    attributesDependencies: [namespace],
+  });
+
   const handleToggleStreaming = () => {
-    toggleStreaming({ query });
+    toggleStreaming({ query, schema });
   };
 
   const handleLoadMoreData = (lastTimestamp: number) => {
     if (!isLoadingMoreLogsData) {
-      getMoreLogs({ lastTimestamp, query, namespace, direction });
+      getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
     }
   };
 
@@ -101,15 +111,16 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
       timeRange,
       direction,
       tenant,
+      schema,
     });
 
     if (isHistogramVisible) {
-      getHistogram({ query: queryToUse ?? query, timeRange, tenant });
+      getHistogram({ query: queryToUse ?? query, timeRange, tenant, schema });
     }
   };
 
   const runVolume = () => {
-    getVolume({ query, tenant, namespace, timeRange });
+    getVolume({ query, tenant, namespace, timeRange, schema });
   };
 
   const handleFiltersChange = (selectedFilters?: Filters) => {
@@ -122,7 +133,8 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
 
     const updatedFilters = filtersFromQuery({
       query: queryFromInput,
-      attributes: initialAvailableAttributes,
+      attributes: initialAvailableAttributes(schema),
+      schema: schema,
     });
 
     setFilters(updatedFilters);
@@ -137,10 +149,11 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
 
     if (hasNoSelectedfilters) {
       const updatedQuery = queryFromFilters({
-        existingQuery: defaultQueryFromTenant(selectedTenant),
+        existingQuery: defaultQueryFromTenant({ tenant: selectedTenant, schema }),
         filters: { namespace: new Set(namespace ? [namespace] : []) },
-        attributes: initialAvailableAttributes,
+        attributes: initialAvailableAttributes(schema),
         tenant: selectedTenant,
+        schema,
       });
 
       setQueryInURL(updatedQuery);
@@ -150,8 +163,9 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
       const updatedQuery = queryFromFilters({
         existingQuery: query,
         filters: selectedFilters,
-        attributes: initialAvailableAttributes,
+        attributes: initialAvailableAttributes(schema),
         tenant: selectedTenant,
+        schema,
       });
 
       setQueryInURL(updatedQuery);
@@ -159,14 +173,6 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
       return updatedQuery;
     }
   };
-
-  const attributeList = React.useMemo(
-    () =>
-      namespace
-        ? availableDevConsoleAttributes(getInitialTenantFromNamespace(namespace), config)
-        : [],
-    [namespace, config],
-  );
 
   React.useEffect(() => {
     tenant = getInitialTenantFromNamespace(namespace);
@@ -259,10 +265,12 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
           onShowStatsToggle={setShowStatsInURL}
           enableTenantDropdown={false}
           isDisabled={isRunQueryDisabled}
-          attributeList={attributeList}
+          attributeList={attributes}
           filters={filters}
           onFiltersChange={handleFiltersChange}
           onDownloadCSV={() => downloadCSV(logsData)}
+          schema={schema}
+          onSchemaSelect={setSchemaInURL}
         />
 
         {isLoadingLogsData ? (
@@ -313,4 +321,12 @@ const LogsDevPage: React.FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => 
   );
 };
 
-export default LogsDevPage;
+const LogsDevPageWrapper: React.FC<LogsDevPageProps> = (props) => {
+  return (
+    <LogsConfigProvider>
+      <LogsDevPage {...props} />
+    </LogsConfigProvider>
+  );
+};
+
+export default LogsDevPageWrapper;

--- a/web/src/parse-resources.tsx
+++ b/web/src/parse-resources.tsx
@@ -1,4 +1,4 @@
-import { Resource } from './logs.types';
+import { Resource, Schema } from './logs.types';
 import { notUndefined } from './value-utils';
 
 export enum ResourceLabel {
@@ -6,9 +6,37 @@ export enum ResourceLabel {
   Namespace = 'Namespace',
   Pod = 'Pod',
   Severity = 'Severity',
+  LogType = 'LogType',
 }
 
-const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string }> = {
+export const getOtelLabels = (): Record<ResourceLabel | 'Schema', string> => {
+  const otelMap = Object.fromEntries(
+    Object.entries(ResourceToStreamLabels).map(([key, value]) => [key, value.otel]),
+  );
+  return {
+    ...otelMap,
+    Schema: Schema.otel, // manually add Schema key
+  } as Record<ResourceLabel | 'Schema', string>;
+};
+
+export const getViaQLabels = (): Record<ResourceLabel | 'Schema', string> => {
+  const otelMap = Object.fromEntries(
+    Object.entries(ResourceToStreamLabels).map(([key, value]) => [key, value.viaq]),
+  );
+  return {
+    ...otelMap,
+    Schema: Schema.viaq, // manually add Schema key
+  } as Record<ResourceLabel | 'Schema', string>;
+};
+
+export const getStreamLabelsFromSchema = (schema: Schema) => {
+  if (schema == Schema.otel) {
+    return getOtelLabels();
+  }
+  return getViaQLabels();
+};
+
+export const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string }> = {
   [ResourceLabel.Container]: {
     otel: 'k8s_container_name',
     viaq: 'kubernetes_container_name',
@@ -24,6 +52,10 @@ const ResourceToStreamLabels: Record<ResourceLabel, { otel: string; viaq: string
   [ResourceLabel.Severity]: {
     otel: 'severity_text',
     viaq: 'level',
+  },
+  [ResourceLabel.LogType]: {
+    otel: 'openshift_log_type',
+    viaq: 'log_type',
   },
 };
 

--- a/web/src/test-ids.ts
+++ b/web/src/test-ids.ts
@@ -22,4 +22,5 @@ export enum TestIds {
   AttributeOptions = 'AttributeOptions',
   NamespaceDropdown = 'NamespaceDropdown',
   NamespaceToggle = 'NamespaceToggle',
+  SchemaToggle = 'SchemaToggle',
 }

--- a/web/src/value-utils.ts
+++ b/web/src/value-utils.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SCHEMA, Schema, SchemaConfig } from './logs.types';
+
 /**
  * Converts a value into a string with scale prefix
  * @example
@@ -87,4 +89,18 @@ export const capitalize = (str?: string): string => {
     return '';
   }
   return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export const getSchema = (value: string | null | undefined | SchemaConfig): Schema => {
+  switch (value) {
+    case Schema.otel:
+    case SchemaConfig.otel:
+      return Schema.otel;
+    case Schema.viaq:
+    case SchemaConfig.viaq:
+      return Schema.viaq;
+
+    default:
+      return DEFAULT_SCHEMA;
+  }
 };


### PR DESCRIPTION
Fixes:

- [OU-731](https://issues.redhat.com/browse/OU-731)
- [OU-313](https://issues.redhat.com/browse/OU-313)

Notable changes:

- @zhuje added the parsing of new otel labels and attributes, and the schema dropdown
- Created a new useLogsConfig hook and provider to share the same config across components and hooks, pages are now wrapped with this provider
- Added the schema configuration to the backend plugin config
- Removed the logs_type matcher if there are other matchers: [OU-313](https://issues.redhat.com//browse/OU-313)
- As initial queries and attributes depend on the selected/configured schema, the useURLState hook now accepts initializer functions for these values
- When changing the schema the current query is updated to match the correct model labels

UX:
Added the schema dropdown, visible only when the config.schema is set to "select"

Pod detail
<img width="1888" alt="Screenshot 2025-05-09 at 10 30 54" src="https://github.com/user-attachments/assets/4ecd499d-a665-4fc8-a85a-7c29d36e604f" />

Dev perspective
<img width="1886" alt="Screenshot 2025-05-09 at 10 30 31" src="https://github.com/user-attachments/assets/fb12b907-9184-4412-afe7-25c2871ddbb4" />

Admin perspective
<img width="1904" alt="Screenshot 2025-05-09 at 10 29 37" src="https://github.com/user-attachments/assets/22a73e06-7d19-48ba-ba67-e4a4b92c281f" />

