### PR TITLE
COO-1554: [release-coo-ocp-4.15] manual backport tls config release-coo-ocp-4.15

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strconv"
@@ -8,18 +9,21 @@ import (
 
 	"github.com/openshift/logging-view-plugin/pkg/server"
 	"github.com/sirupsen/logrus"
+	k8sapiflag "k8s.io/component-base/cli/flag"
 )
 
 var (
-	portArg         = flag.Int("port", 0, "server port to listen on (default: 9002)")
-	certArg         = flag.String("cert", "", "cert file path to enable TLS (disabled by default)")
-	keyArg          = flag.String("key", "", "private key file path to enable TLS (disabled by default)")
-	featuresArg     = flag.String("features", "", "enabled features, comma separated")
-	staticPathArg   = flag.String("static-path", "", "static files path to serve frontend (default: './web/dist')")
-	configPathArg   = flag.String("config-path", "", "config files path (default: './config')")
-	pluginConfigArg = flag.String("plugin-config-path", "", "plugin yaml configuration")
-	logLevelArg     = flag.String("log-level", logrus.InfoLevel.String(), "verbosity of logs\noptions: ['panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']\n'trace' level will log all incoming requests\n(default 'error')")
-	log             = logrus.WithField("module", "main")
+	portArg            = flag.Int("port", 0, "server port to listen on (default: 9002)")
+	certArg            = flag.String("cert", "", "cert file path to enable TLS (disabled by default)")
+	keyArg             = flag.String("key", "", "private key file path to enable TLS (disabled by default)")
+	featuresArg        = flag.String("features", "", "enabled features, comma separated")
+	staticPathArg      = flag.String("static-path", "", "static files path to serve frontend (default: './web/dist')")
+	configPathArg      = flag.String("config-path", "", "config files path (default: './config')")
+	pluginConfigArg    = flag.String("plugin-config-path", "", "plugin yaml configuration")
+	logLevelArg        = flag.String("log-level", logrus.InfoLevel.String(), "verbosity of logs\noptions: ['panic', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']\n'trace' level will log all incoming requests\n(default 'error')")
+	log                = logrus.WithField("module", "main")
+	tlsMinVersionArg   = flag.String("tls-min-version", "VersionTLS12", "minimum TLS version (VersionTLS12, VersionTLS13)")
+	tlsCipherSuitesArg = flag.String("tls-cipher-suites", "", "comma-separated list of cipher suites")
 )
 
 func main() {
@@ -33,6 +37,8 @@ func main() {
 	configPath := mergeEnvValue("LOGGING_VIEW_PLUGIN_MANIFEST_CONFIG_PATH", *configPathArg, "./config")
 	pluginConfigPath := mergeEnvValue("LOGGING_VIEW_PLUGIN_CONFIG_PATH", *pluginConfigArg, "/etc/plugin/config.yaml")
 	logLevel := mergeEnvValue("LOGGING_VIEW_PLUGIN_LOG_LEVEL", *logLevelArg, logrus.InfoLevel.String())
+	tlsMinVersion := mergeEnvValue("TLS_MIN_VERSION", *tlsMinVersionArg, "VersionTLS12")
+	tlsCipherSuites := mergeEnvValue("TLS_CIPHER_SUITES", *tlsCipherSuitesArg, "")
 
 	featuresList := strings.Fields(strings.Join(strings.Split(strings.ToLower(features), ","), " "))
 
@@ -49,9 +55,24 @@ func main() {
 
 	logrus.SetLevel(logrusLevel)
 
+	// Parse TLS configuration
+	tlsMinVer, err := k8sapiflag.TLSVersion(tlsMinVersion)
+	if err != nil {
+		log.Fatalf("Invalid TLS min version %q: %v", tlsMinVersion, err)
+	}
+
+	var tlsCiphers []uint16
+	if tlsCipherSuites != "" {
+		cipherNames := strings.Split(strings.ReplaceAll(tlsCipherSuites, " ", ""), ",")
+		tlsCiphers, err = k8sapiflag.TLSCipherSuites(cipherNames)
+		if err != nil {
+			log.Fatalf("Invalid TLS cipher suites %q: %v", tlsCipherSuites, err)
+		}
+	}
+
 	log.Infof("enabled features: %+q\n", featuresList)
 
-	server.Start(&server.Config{
+	srv, err := server.CreateServer(context.Background(), &server.Config{
 		Port:             port,
 		CertFile:         cert,
 		PrivateKeyFile:   key,
@@ -59,7 +80,17 @@ func main() {
 		StaticPath:       staticPath,
 		ConfigPath:       configPath,
 		PluginConfigPath: pluginConfigPath,
+		TLSMinVersion:    tlsMinVer,
+		TLSCipherSuites:  tlsCiphers,
 	})
+
+	if err != nil {
+		log.Fatalf("Failed to create server: %v", err)
+	}
+
+	if err := srv.StartHTTPServer(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
 }
 
 func mergeEnvValue(key string, arg string, defaultValue string) string {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.31.1
 	k8s.io/apiserver v0.31.1
 	k8s.io/client-go v0.31.1
+	k8s.io/component-base v0.31.1
 )
 
 require (
@@ -31,6 +32,7 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -39,6 +41,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -47,6 +48,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -71,8 +74,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
-github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
-github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
+github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
+github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -80,8 +83,11 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -163,6 +169,8 @@ k8s.io/apiserver v0.31.1 h1:Sars5ejQDCRBY5f7R3QFHdqN3s61nhkpaX8/k1iEw1c=
 k8s.io/apiserver v0.31.1/go.mod h1:lzDhpeToamVZJmmFlaLwdYZwd7zB+WYRYIboqA1kGxM=
 k8s.io/client-go v0.31.1 h1:f0ugtWSbWpxHR7sjVpQwuvw9a3ZKLXX0u0itkFXufb0=
 k8s.io/client-go v0.31.1/go.mod h1:sKI8871MJN2OyeqRlmA4W4KM9KBdBUpDLu/43eGemCg=
+k8s.io/component-base v0.31.1 h1:UpOepcrX3rQ3ab5NB6g5iP0tvsgJWzxTyAo20sgYSy8=
+k8s.io/component-base v0.31.1/go.mod h1:WGeaw7t/kTsqpVTaCoVEtillbqAhF2/JgvO0LDOMa0w=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7FjZpUb45WallggurYhKGag=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,55 @@ type Config struct {
 	StaticPath       string
 	ConfigPath       string
 	PluginConfigPath string
+	TLSMinVersion    uint16
+	TLSCipherSuites  []uint16
+}
+
+func (cfg *Config) IsTLSEnabled() bool {
+	return cfg.CertFile != "" && cfg.PrivateKeyFile != ""
+}
+
+func (cfg *Config) ValidateTLSConfig() error {
+	if !cfg.IsTLSEnabled() {
+		return nil
+	}
+
+	if _, err := os.Stat(cfg.CertFile); err != nil {
+		return fmt.Errorf("cert file error: %v", err)
+	}
+
+	if _, err := os.Stat(cfg.PrivateKeyFile); err != nil {
+		return fmt.Errorf("key file error: %v", err)
+	}
+
+	return nil
+}
+
+type PluginServer struct {
+	*http.Server
+	Config *Config
+	cancel context.CancelFunc
+}
+
+// StartHTTPServer starts the HTTP orHTTPS server
+func (s *PluginServer) StartHTTPServer() error {
+	if s.Config.IsTLSEnabled() {
+		slog.Infof("listening for https on %s", s.Addr)
+		return s.ListenAndServeTLS(s.Config.CertFile, s.Config.PrivateKeyFile)
+	}
+	slog.Infof("listening for http on %s", s.Addr)
+	return s.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the server
+func (s *PluginServer) Shutdown(ctx context.Context) error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.Server != nil {
+		return s.Server.Shutdown(ctx)
+	}
+	return nil
 }
 
 type PluginConfig struct {
@@ -55,7 +104,11 @@ func (pluginConfig *PluginConfig) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func Start(cfg *Config) {
+func CreateServer(ctx context.Context, cfg *Config) (*PluginServer, error) {
+	if err := cfg.ValidateTLSConfig(); err != nil {
+		return nil, fmt.Errorf("TLS config validation failed: %v", err)
+	}
+
 	router := setupRoutes(cfg)
 	router.Use(corsHeaderMiddleware(cfg))
 
@@ -64,19 +117,32 @@ func Start(cfg *Config) {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	tlsEnabled := cfg.CertFile != "" && cfg.PrivateKeyFile != ""
-	if tlsEnabled {
+	// Apply custom TLS settings if provided
+	if cfg.TLSMinVersion != 0 {
+		tlsConfig.MinVersion = cfg.TLSMinVersion
+	}
+
+	if len(cfg.TLSCipherSuites) > 0 {
+		tlsConfig.CipherSuites = cfg.TLSCipherSuites
+	}
+
+	var cancel context.CancelFunc
+	if cfg.IsTLSEnabled() {
+		var serverCtx context.Context
+		serverCtx, cancel = context.WithCancel(ctx)
+
 		// Build and run the controller which reloads the certificate and key
 		// files whenever they change.
-		ctx := context.Background()
 
 		certKeyPair, err := dynamiccertificates.NewDynamicServingContentFromFiles("serving-cert", cfg.CertFile, cfg.PrivateKeyFile)
 		if err != nil {
-			slog.WithError(err).Fatal("unable to create TLS controller")
+			cancel()
+			return nil, fmt.Errorf("unable to create TLS controller: %v", err)
 		}
 
-		if err := certKeyPair.RunOnce(ctx); err != nil {
-			slog.WithError(err).Fatal("failed to initialize cert/key content")
+		if err := certKeyPair.RunOnce(serverCtx); err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to initialize cert/key content: %v", err)
 		}
 
 		eventBroadcaster := record.NewBroadcaster()
@@ -100,8 +166,8 @@ func Start(cfg *Config) {
 		// Notify cert/key file changes to the controller.
 		certKeyPair.AddListener(ctrl)
 
-		go ctrl.Run(1, ctx.Done())
-		go certKeyPair.Run(ctx, 1)
+		go ctrl.Run(1, serverCtx.Done())
+		go certKeyPair.Run(serverCtx, 1)
 	}
 
 	httpServer := &http.Server{
@@ -117,12 +183,22 @@ func Start(cfg *Config) {
 		httpServer.Handler = loggedRouter
 	}
 
-	if tlsEnabled {
-		slog.Infof("listening for https on %s", httpServer.Addr)
-		panic(httpServer.ListenAndServeTLS(cfg.CertFile, cfg.PrivateKeyFile))
-	} else {
-		slog.Infof("listening for http on %s", httpServer.Addr)
-		panic(httpServer.ListenAndServe())
+	return &PluginServer{
+		Server: httpServer,
+		Config: cfg,
+		cancel: cancel,
+	}, nil
+}
+
+func Start(cfg *Config) {
+	ctx := context.Background()
+	srv, err := CreateServer(ctx, cfg)
+	if err != nil {
+		slog.WithError(err).Fatal("failed to create server")
+	}
+
+	if err := srv.StartHTTPServer(); err != nil {
+		slog.WithError(err).Fatal("failed to start server")
 	}
 }
 
@@ -146,6 +222,24 @@ func setupRoutes(cfg *Config) *mux.Router {
 	return r
 }
 
+type headerPreservingWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *headerPreservingWriter) WriteHeader(statusCode int) {
+	if !w.wroteHeader {
+		if w.Header().Get("Cache-Control") == "" {
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		}
+		if w.Header().Get("Expires") == "" {
+			w.Header().Set("Expires", "0")
+		}
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
 func filesHandler(root http.FileSystem) http.Handler {
 	fileServer := http.FileServer(root)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -155,6 +249,8 @@ func filesHandler(root http.FileSystem) http.Handler {
 		if strings.HasPrefix(filePath, "/plugin-entry.js") {
 			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 			w.Header().Set("Expires", "0")
+			fileServer.ServeHTTP(&headerPreservingWriter{ResponseWriter: w}, r)
+			return
 		}
 
 		fileServer.ServeHTTP(w, r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,14 @@ func (cfg *Config) IsTLSEnabled() bool {
 }
 
 func (cfg *Config) ValidateTLSConfig() error {
-	if !cfg.IsTLSEnabled() {
+	certSet := cfg.CertFile != ""
+	keySet := cfg.PrivateKeyFile != ""
+
+	if certSet != keySet {
+		return fmt.Errorf("both CertFile and PrivateKeyFile must be provided to enable TLS")
+	}
+
+	if !certSet && !keySet {
 		return nil
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -667,3 +667,60 @@ func TestTLSConfigMinVersionOnly(t *testing.T) {
 		t.Fatalf("Failed: should not have been able to connect with TLS 1.2 when min is TLS 1.3")
 	}
 }
+
+func TestTLSConfigValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		certFile       string
+		privateKeyFile string
+		expectError    bool
+		expectedError  string
+	}{
+		{
+			name:           "no TLS config - valid",
+			certFile:       "",
+			privateKeyFile: "",
+			expectError:    false,
+		},
+		{
+			name:           "both cert and key provided - valid when files exist",
+			certFile:       "/valid/cert.pem",
+			privateKeyFile: "/valid/key.pem",
+			expectError:    true, // Files don't exist, but that's expected
+		},
+		{
+			name:           "only cert file provided - invalid",
+			certFile:       "/path/to/cert.pem",
+			privateKeyFile: "",
+			expectError:    true,
+			expectedError:  "both CertFile and PrivateKeyFile must be provided to enable TLS",
+		},
+		{
+			name:           "only key file provided - invalid",
+			certFile:       "",
+			privateKeyFile: "/path/to/key.pem",
+			expectError:    true,
+			expectedError:  "both CertFile and PrivateKeyFile must be provided to enable TLS",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				CertFile:       tc.certFile,
+				PrivateKeyFile: tc.privateKeyFile,
+			}
+
+			err := cfg.ValidateTLSConfig()
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.expectedError != "" {
+					require.Contains(t, err.Error(), tc.expectedError)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -52,11 +53,10 @@ func TestServerRunning(t *testing.T) {
 	tmpDir := prepareServerAssets(t)
 	defer os.RemoveAll(tmpDir)
 
-	go func() {
-		Start(&Config{
-			Port: testPort,
-		})
-	}()
+	_, cleanup := startTestServer(t, &Config{
+		Port: testPort,
+	})
+	defer cleanup()
 
 	t.Logf("Started test http server: %v", serverURL)
 
@@ -138,9 +138,8 @@ func TestSecureServerRunning(t *testing.T) {
 	tmpDirAssets := prepareServerAssets(t)
 	defer os.RemoveAll(tmpDirAssets)
 
-	go func() {
-		Start(conf)
-	}()
+	_, cleanup := startTestServer(t, conf)
+	defer cleanup()
 	t.Logf("Started test http server: %v", serverURL)
 
 	httpConfig := httpClientConfig{
@@ -285,6 +284,32 @@ func (conf *httpClientConfig) buildHTTPClient() (*http.Client, error) {
 	return &httpClient, nil
 }
 
+func startTestServer(t *testing.T, cfg *Config) (*PluginServer, func()) {
+	ctx := context.Background()
+	srv, err := CreateServer(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	// Start server in background
+	go func() {
+		if err := srv.StartHTTPServer(); err != nil {
+			t.Logf("Server stopped: %v", err)
+		}
+	}()
+
+	// Return cleanup function that shuts down the server
+	cleanup := func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			t.Logf("Failed to shutdown server: %v", err)
+		}
+	}
+
+	return srv, cleanup
+}
+
 func generateCertificate(t *testing.T, certPath string, keyPath string, host string) error {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -374,5 +399,271 @@ func TestFilesHandler(t *testing.T) {
 	}
 	if res.Header.Get("Expires") != "0" {
 		t.Errorf("Expected Expires header %q, but got %q", "0", res.Header.Get("Expires"))
+	}
+}
+
+func TestTLSConfigWithCustomSettings(t *testing.T) {
+	testPort, err := getFreePort(testHostname)
+	require.NoError(t, err)
+	t.Logf("Will use free port [%v] on host [%v] for tests", testPort, testHostname)
+
+	tmpDir, err := os.MkdirTemp("", "server-test-tls")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testServerCertFile := tmpDir + "/server-test-tls.cert"
+	testServerKeyFile := tmpDir + "/server-test-tls.key"
+	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
+	err = generateCertificate(t, testServerCertFile, testServerKeyFile, testServerHostPort)
+	require.NoError(t, err)
+
+	testClientCertFile := tmpDir + "/client-test-tls.cert"
+	testClientKeyFile := tmpDir + "/client-test-tls.key"
+	err = generateCertificate(t, testClientCertFile, testClientKeyFile, testHostname)
+	require.NoError(t, err)
+
+	conf := &Config{
+		CertFile:        testServerCertFile,
+		PrivateKeyFile:  testServerKeyFile,
+		Port:            testPort,
+		TLSMinVersion:   tls.VersionTLS12,
+		TLSCipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+	}
+
+	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
+
+	tmpDirAssets := prepareServerAssets(t)
+	defer os.RemoveAll(tmpDirAssets)
+
+	srv, cleanup := startTestServer(t, conf)
+	defer cleanup()
+	t.Logf("Started test https server with custom TLS config: %v", serverURL)
+
+	// Verify TLS configuration is applied
+	require.Equal(t, uint16(tls.VersionTLS12), srv.TLSConfig.MinVersion)
+	require.Equal(t, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384}, srv.TLSConfig.CipherSuites)
+	require.NotNil(t, srv.TLSConfig.GetConfigForClient, "GetConfigForClient should be set for certificate rotation")
+
+	// Test TLS 1.3 client - should succeed
+	httpConfigTLS13 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS13,
+			MaxVersion:         tls.VersionTLS13,
+		},
+	}
+	httpClientTLS13, err := httpConfigTLS13.buildHTTPClient()
+	require.NoError(t, err)
+
+	checkHTTPReady(httpClientTLS13, serverURL+"/health")
+
+	if _, err = getRequestResults(t, httpClientTLS13, serverURL+"/health"); err != nil {
+		t.Fatalf("Failed: could not connect with TLS 1.3: %v", err)
+	}
+
+	// Test TLS 1.2 client with matching cipher suite - should succeed
+	httpConfigTLS12 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			MaxVersion:         tls.VersionTLS12,
+			CipherSuites:       []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		},
+	}
+	httpClientTLS12, err := httpConfigTLS12.buildHTTPClient()
+	require.NoError(t, err)
+
+	if _, err = getRequestResults(t, httpClientTLS12, serverURL+"/health"); err != nil {
+		t.Fatalf("Failed: could not connect with TLS 1.2: %v", err)
+	}
+
+	// Test TLS 1.1 client - should fail
+	httpConfigTLS11 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS10,
+			MaxVersion:         tls.VersionTLS11,
+		},
+	}
+	httpClientTLS11, err := httpConfigTLS11.buildHTTPClient()
+	require.NoError(t, err)
+
+	if _, err = getRequestResults(t, httpClientTLS11, serverURL+"/health"); err == nil {
+		t.Fatalf("Failed: should not have been able to connect with TLS 1.1")
+	}
+}
+
+func TestTLSConfigWithDefaults(t *testing.T) {
+	testPort, err := getFreePort(testHostname)
+	require.NoError(t, err)
+	t.Logf("Will use free port [%v] on host [%v] for tests", testPort, testHostname)
+
+	tmpDir, err := os.MkdirTemp("", "server-test-tls-defaults")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testServerCertFile := tmpDir + "/server-defaults.cert"
+	testServerKeyFile := tmpDir + "/server-defaults.key"
+	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
+	err = generateCertificate(t, testServerCertFile, testServerKeyFile, testServerHostPort)
+	require.NoError(t, err)
+
+	testClientCertFile := tmpDir + "/client-defaults.cert"
+	testClientKeyFile := tmpDir + "/client-defaults.key"
+	err = generateCertificate(t, testClientCertFile, testClientKeyFile, testHostname)
+	require.NoError(t, err)
+
+	conf := &Config{
+		CertFile:       testServerCertFile,
+		PrivateKeyFile: testServerKeyFile,
+		Port:           testPort,
+		// No TLS settings - should use Go defaults
+	}
+
+	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
+
+	tmpDirAssets := prepareServerAssets(t)
+	defer os.RemoveAll(tmpDirAssets)
+
+	srv, cleanup := startTestServer(t, conf)
+	defer cleanup()
+	t.Logf("Started test https server with default TLS config: %v", serverURL)
+
+	// Verify default TLS configuration
+	require.Equal(t, uint16(tls.VersionTLS12), srv.TLSConfig.MinVersion, "Should default to TLS 1.2")
+	require.Nil(t, srv.TLSConfig.CipherSuites, "Should use system default cipher suites when not specified")
+	require.NotNil(t, srv.TLSConfig.GetConfigForClient, "GetConfigForClient should be set for certificate rotation")
+
+	// Test TLS 1.2 client - should succeed
+	httpConfigTLS12 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+		},
+	}
+	httpClientTLS12, err := httpConfigTLS12.buildHTTPClient()
+	require.NoError(t, err)
+
+	checkHTTPReady(httpClientTLS12, serverURL+"/health")
+
+	if _, err = getRequestResults(t, httpClientTLS12, serverURL+"/health"); err != nil {
+		t.Fatalf("Failed: could not connect with TLS 1.2: %v", err)
+	}
+
+	// Test TLS 1.3 client - should succeed
+	httpConfigTLS13 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS13,
+		},
+	}
+	httpClientTLS13, err := httpConfigTLS13.buildHTTPClient()
+	require.NoError(t, err)
+
+	if _, err = getRequestResults(t, httpClientTLS13, serverURL+"/health"); err != nil {
+		t.Fatalf("Failed: could not connect with TLS 1.3: %v", err)
+	}
+
+	// Test TLS 1.1 client - should fail
+	httpConfigTLS11 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MaxVersion:         tls.VersionTLS11,
+		},
+	}
+	httpClientTLS11, err := httpConfigTLS11.buildHTTPClient()
+	require.NoError(t, err)
+
+	if _, err = getRequestResults(t, httpClientTLS11, serverURL+"/health"); err == nil {
+		t.Fatalf("Failed: should not have been able to connect with TLS 1.1")
+	}
+}
+
+func TestTLSConfigMinVersionOnly(t *testing.T) {
+	testPort, err := getFreePort(testHostname)
+	require.NoError(t, err)
+
+	tmpDir, err := os.MkdirTemp("", "server-test-tls-minonly")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testServerCertFile := tmpDir + "/server-minonly.cert"
+	testServerKeyFile := tmpDir + "/server-minonly.key"
+	testServerHostPort := fmt.Sprintf("%v:%v", testHostname, testPort)
+	err = generateCertificate(t, testServerCertFile, testServerKeyFile, testServerHostPort)
+	require.NoError(t, err)
+
+	testClientCertFile := tmpDir + "/client-minonly.cert"
+	testClientKeyFile := tmpDir + "/client-minonly.key"
+	err = generateCertificate(t, testClientCertFile, testClientKeyFile, testHostname)
+	require.NoError(t, err)
+
+	conf := &Config{
+		CertFile:       testServerCertFile,
+		PrivateKeyFile: testServerKeyFile,
+		Port:           testPort,
+		TLSMinVersion:  tls.VersionTLS13,
+		// No MaxVersion - should allow TLS 1.3
+	}
+
+	serverURL := fmt.Sprintf("https://%s", testServerHostPort)
+
+	tmpDirAssets := prepareServerAssets(t)
+	defer os.RemoveAll(tmpDirAssets)
+
+	srv, cleanup := startTestServer(t, conf)
+	defer cleanup()
+	t.Logf("Started test https server with TLS 1.3 minimum: %v", serverURL)
+
+	// Verify TLS configuration was applied correctly
+	require.Equal(t, uint16(tls.VersionTLS13), srv.TLSConfig.MinVersion)
+	require.Nil(t, srv.TLSConfig.CipherSuites, "Should use system default cipher suites when not specified")
+	require.NotNil(t, srv.TLSConfig.GetConfigForClient, "GetConfigForClient should be set for certificate rotation")
+
+	// Test TLS 1.3 client - should succeed
+	httpConfigTLS13 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS13,
+		},
+	}
+	httpClientTLS13, err := httpConfigTLS13.buildHTTPClient()
+	require.NoError(t, err)
+
+	checkHTTPReady(httpClientTLS13, serverURL+"/health")
+
+	if _, err = getRequestResults(t, httpClientTLS13, serverURL+"/health"); err != nil {
+		t.Fatalf("Failed: could not connect with TLS 1.3: %v", err)
+	}
+
+	// Test TLS 1.2 client - should fail
+	httpConfigTLS12 := httpClientConfig{
+		CertFile:       testClientCertFile,
+		PrivateKeyFile: testClientKeyFile,
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			MaxVersion:         tls.VersionTLS12,
+		},
+	}
+	httpClientTLS12, err := httpConfigTLS12.buildHTTPClient()
+	require.NoError(t, err)
+
+	if _, err = getRequestResults(t, httpClientTLS12, serverURL+"/health"); err == nil {
+		t.Fatalf("Failed: should not have been able to connect with TLS 1.2 when min is TLS 1.3")
 	}
 }


### PR DESCRIPTION
JIRA 
https://redhat.atlassian.net/browse/COO-1554

image: 
quay.io/jezhu/logging-view-plugin:coo1554-tls-backport-release-coo-ocp-4.15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable TLS support allowing users to set minimum protocol version and cipher suites via CLI flags and environment variables.

* **Improvements**
  * Enhanced server initialization with comprehensive TLS configuration validation and improved error reporting on startup failures.

* **Tests**
  * Expanded test coverage for TLS configurations, including custom and default settings validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->