### PR TITLE
OU-737: bugfix: add nanosecond precision to load more calculation to avoid loosing logs on high volume results

### DIFF
--- a/web/src/__tests__/value-utils.spec.ts
+++ b/web/src/__tests__/value-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   millisecondsFromDuration,
   valueWithScalePrefix,
   capitalize,
+  msToNs,
 } from '../value-utils';
 
 describe('value utils', () => {
@@ -41,5 +42,14 @@ describe('value utils', () => {
     expect(capitalize('')).toBe('');
     expect(capitalize('123')).toBe('123');
     expect(capitalize()).toBe('');
+  });
+
+  it('should convert milliseconds to nanosecond strings', () => {
+    expect(msToNs(0)).toBe('0');
+    expect(msToNs(1)).toBe('1000000');
+    expect(msToNs(1000)).toBe('1000000000');
+    expect(msToNs(1666003060000)).toBe('1666003060000000000');
+    expect(msToNs(1000.7)).toBe('1001000000');
+    expect(msToNs(1000.3)).toBe('1000000000');
   });
 });

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -39,7 +39,7 @@ interface LogsTableProps {
   isLoading?: boolean;
   hasMoreLogsData?: boolean;
   isLoadingMore?: boolean;
-  onLoadMore?: (lastTimestamp: number) => void;
+  onLoadMore?: (lastTimestamp: string) => void;
   onSortByDate?: (direction?: Direction) => void;
   direction?: Direction;
   showResources?: boolean;
@@ -80,6 +80,7 @@ const streamToTableData = (stream: StreamLogData, timezone?: string): Array<LogT
     return {
       time: formattedTime,
       timestamp,
+      rawTimestamp,
       message,
       severity: severityFromString(severity) ?? 'other',
       data: stream.stream,
@@ -361,7 +362,7 @@ export const LogsTable: FC<PropsWithChildren<LogsTableProps>> = ({
   const dataIsEmpty = sortedData.length === 0;
 
   const handleLoadMore = () => {
-    onLoadMore?.(tableData[tableData.length - 1].timestamp / 1e6);
+    onLoadMore?.(tableData[tableData.length - 1].rawTimestamp);
   };
 
   const RowComponent = useMemo(

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -39,7 +39,7 @@ interface LogsTableProps {
   isLoading?: boolean;
   hasMoreLogsData?: boolean;
   isLoadingMore?: boolean;
-  onLoadMore?: (lastTimestamp: string) => void;
+  onLoadMore?: (lastTimestampNs: string) => void;
   onSortByDate?: (direction?: Direction) => void;
   direction?: Direction;
   showResources?: boolean;

--- a/web/src/hooks/useLogs.ts
+++ b/web/src/hooks/useLogs.ts
@@ -251,8 +251,6 @@ export const useLogs = (
   const currentQuery = useRef<string | undefined>();
   const currentTenant = useRef<string>(initialTenant);
   const currentTimeRange = useRef<TimeRange>(initialTimeRange);
-  // eslint-disable-next-line react-hooks/purity
-  const currentTime = useRef<number>(Date.now());
   const lastExecutionTime = useRef<{ logs?: number; histogram?: number; volume?: number }>({
     logs: undefined,
     histogram: undefined,
@@ -319,7 +317,6 @@ export const useLogs = (
 
     try {
       currentQuery.current = query;
-      currentTime.current = Date.now();
       currentDirection.current = direction ?? currentDirection.current;
 
       const lastTs = BigInt(lastTimestamp);
@@ -398,7 +395,6 @@ export const useLogs = (
     try {
       currentQuery.current = query;
       currentTenant.current = tenant ?? currentTenant.current;
-      currentTime.current = Date.now();
       lastExecutionTime.current.logs = Date.now();
       currentTimeRange.current = timeRange ?? currentTimeRange.current;
       currentDirection.current = direction ?? currentDirection.current;
@@ -457,7 +453,6 @@ export const useLogs = (
   }) => {
     currentQuery.current = query;
     currentTenant.current = tenant ?? currentTenant.current;
-    currentTime.current = Date.now();
 
     if (ws.current) {
       ws.current.destroy();
@@ -544,7 +539,6 @@ export const useLogs = (
     try {
       currentQuery.current = query;
       currentTenant.current = tenant ?? currentTenant.current;
-      currentTime.current = Date.now();
       lastExecutionTime.current.logs = Date.now();
       currentTimeRange.current = timeRange ?? currentTimeRange.current;
 
@@ -619,7 +613,6 @@ export const useLogs = (
     try {
       currentQuery.current = query;
       currentTenant.current = tenant ?? currentTenant.current;
-      currentTime.current = Date.now();
       lastExecutionTime.current.histogram = Date.now();
       currentTimeRange.current = timeRange ?? currentTimeRange.current;
 

--- a/web/src/hooks/useLogs.ts
+++ b/web/src/hooks/useLogs.ts
@@ -16,6 +16,7 @@ import {
   executeVolumeRange,
 } from '../loki-client';
 import { intervalFromTimeRange, numericTimeRange, timeRangeFromDuration } from '../time-range';
+import { msToNs } from '../value-utils';
 
 import { LogQLQuery } from '../logql-query';
 import { LogsContext } from './LogsConfigProvider';
@@ -298,13 +299,13 @@ export const useLogs = (
   });
 
   const getMoreLogs = async ({
-    lastTimestamp,
+    lastTimestampNs,
     query,
     namespace,
     direction,
     schema,
   }: {
-    lastTimestamp: string;
+    lastTimestampNs: string;
     query: string;
     namespace?: string;
     direction?: Direction;
@@ -319,7 +320,7 @@ export const useLogs = (
       currentQuery.current = query;
       currentDirection.current = direction ?? currentDirection.current;
 
-      const lastTs = BigInt(lastTimestamp);
+      const lastTs = BigInt(lastTimestampNs);
       const oneHourNs = 3_600_000_000_000n;
 
       let startNs: string;
@@ -330,7 +331,7 @@ export const useLogs = (
         endNs = String(lastTs + oneHourNs);
       } else {
         startNs = String(lastTs - oneHourNs);
-        endNs = String(lastTs - 1n);
+        endNs = String(lastTs);
       }
 
       dispatch({ type: 'moreLogsRequest' });
@@ -343,8 +344,8 @@ export const useLogs = (
 
       const { request, abort } = executeQueryRange({
         query,
-        start: startNs,
-        end: endNs,
+        startNs,
+        endNs,
         config,
         tenant: currentTenant.current,
         namespace,
@@ -411,8 +412,8 @@ export const useLogs = (
 
       const { request, abort } = executeQueryRange({
         query,
-        start: String(start * 1000000),
-        end: String(end * 1000000),
+        startNs: msToNs(start),
+        endNs: msToNs(end),
         config,
         tenant: currentTenant.current,
         namespace,
@@ -465,6 +466,7 @@ export const useLogs = (
       tenant: currentTenant.current,
       namespace,
       schema,
+      config: configRef.current,
     });
 
     ws.current.onerror((error) => {
@@ -539,7 +541,7 @@ export const useLogs = (
     try {
       currentQuery.current = query;
       currentTenant.current = tenant ?? currentTenant.current;
-      lastExecutionTime.current.logs = Date.now();
+      lastExecutionTime.current.volume = Date.now();
       currentTimeRange.current = timeRange ?? currentTimeRange.current;
 
       const { start, end } = numericTimeRange(currentTimeRange.current);
@@ -564,8 +566,8 @@ export const useLogs = (
 
       const { request, abort } = executeVolumeRange({
         query,
-        start,
-        end,
+        startNs: msToNs(start),
+        endNs: msToNs(end),
         config,
         tenant: currentTenant.current,
         namespace,
@@ -629,8 +631,8 @@ export const useLogs = (
 
       const { request, abort } = executeHistogramQuery({
         query,
-        start,
-        end,
+        startNs: msToNs(start),
+        endNs: msToNs(end),
         interval: intervalFromTimeRange(currentTimeRange.current),
         config,
         tenant: currentTenant.current,

--- a/web/src/hooks/useLogs.ts
+++ b/web/src/hooks/useLogs.ts
@@ -16,7 +16,6 @@ import {
   executeVolumeRange,
 } from '../loki-client';
 import { intervalFromTimeRange, numericTimeRange, timeRangeFromDuration } from '../time-range';
-import { millisecondsFromDuration } from '../value-utils';
 
 import { LogQLQuery } from '../logql-query';
 import { LogsContext } from './LogsConfigProvider';
@@ -307,7 +306,7 @@ export const useLogs = (
     direction,
     schema,
   }: {
-    lastTimestamp: number;
+    lastTimestamp: string;
     query: string;
     namespace?: string;
     direction?: Direction;
@@ -323,14 +322,18 @@ export const useLogs = (
       currentTime.current = Date.now();
       currentDirection.current = direction ?? currentDirection.current;
 
-      const oneHourMilliseconds = millisecondsFromDuration('1h');
+      const lastTs = BigInt(lastTimestamp);
+      const oneHourNs = 3_600_000_000_000n;
 
-      let start = lastTimestamp - oneHourMilliseconds;
-      let end = lastTimestamp - 1;
+      let startNs: string;
+      let endNs: string;
 
       if (currentDirection.current === 'forward') {
-        start = lastTimestamp + 1;
-        end = lastTimestamp + oneHourMilliseconds;
+        startNs = String(lastTs + 1n);
+        endNs = String(lastTs + oneHourNs);
+      } else {
+        startNs = String(lastTs - oneHourNs);
+        endNs = String(lastTs - 1n);
       }
 
       dispatch({ type: 'moreLogsRequest' });
@@ -343,8 +346,8 @@ export const useLogs = (
 
       const { request, abort } = executeQueryRange({
         query,
-        start,
-        end,
+        start: startNs,
+        end: endNs,
         config,
         tenant: currentTenant.current,
         namespace,
@@ -412,8 +415,8 @@ export const useLogs = (
 
       const { request, abort } = executeQueryRange({
         query,
-        start,
-        end,
+        start: String(start * 1000000),
+        end: String(end * 1000000),
         config,
         tenant: currentTenant.current,
         namespace,

--- a/web/src/logs.types.ts
+++ b/web/src/logs.types.ts
@@ -111,6 +111,7 @@ export type Resource = {
 export type LogTableData = {
   time: string;
   timestamp: number;
+  rawTimestamp: string;
   severity: string;
   namespace?: string;
   podName?: string;

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -19,8 +19,8 @@ const LOKI_ENDPOINT = '/api/proxy/plugin/logging-view-plugin/backend';
 
 type QueryRangeParams = {
   query: string;
-  start: string;
-  end: string;
+  startNs: string;
+  endNs: string;
   config?: Config;
   namespace?: string;
   tenant: string;
@@ -30,8 +30,8 @@ type QueryRangeParams = {
 
 type VolumeRangeParams = {
   query: string;
-  start: number;
-  end: number;
+  startNs: string;
+  endNs: string;
   config?: Config;
   namespace?: string;
   tenant: string;
@@ -41,8 +41,8 @@ type VolumeRangeParams = {
 
 type HistogramQuerParams = {
   query: string;
-  start: number;
-  end: number;
+  startNs: string;
+  endNs: string;
   interval: number;
   config?: Config;
   namespace?: string;
@@ -52,16 +52,14 @@ type HistogramQuerParams = {
 
 type LokiTailQueryParams = {
   query: string;
-  delay_for?: string;
-  limit?: number;
-  start?: number;
+  startNs?: string;
   config?: Config;
   namespace?: string;
   tenant: string;
   schema: Schema;
 };
 
-const MAX_RANGE_REQUEST = 60 * 60 * 6 * 1000; // 6 hours
+const MAX_RANGE_REQUEST_NS = 21_600_000_000_000n; // 6 hours in nanoseconds
 
 export const getFetchConfig = ({
   config,
@@ -139,8 +137,8 @@ export const executeSeries = ({
 
 export const executeQueryRange = ({
   query,
-  start,
-  end,
+  startNs,
+  endNs,
   config,
   tenant,
   namespace,
@@ -155,8 +153,8 @@ export const executeQueryRange = ({
 
   const params: Record<string, string> = {
     query: extendedQuery,
-    start,
-    end,
+    start: startNs,
+    end: endNs,
     limit: String(config?.logsLimit ?? 100),
   };
 
@@ -174,8 +172,8 @@ export const executeQueryRange = ({
 
 export const executeVolumeRange = ({
   query,
-  start,
-  end,
+  startNs,
+  endNs,
   config,
   tenant,
   namespace,
@@ -189,8 +187,8 @@ export const executeVolumeRange = ({
 
   const params: Record<string, string> = {
     query: extendedQuery,
-    start: String(start * 1000000),
-    end: String(end * 1000000),
+    start: startNs,
+    end: endNs,
   };
 
   const { endpoint, requestInit } = getFetchConfig({ config, tenant });
@@ -201,26 +199,28 @@ export const executeVolumeRange = ({
   );
 };
 
-const splitQueryRange = (start: number, end: number) => {
-  const ranges = [];
+const splitQueryRange = (startNs: string, endNs: string): string[][] => {
+  const start = BigInt(startNs);
+  const end = BigInt(endNs);
+  const ranges: string[][] = [];
   let currentStart = start;
-  let currentEnd = start + MAX_RANGE_REQUEST;
+  let currentEnd = start + MAX_RANGE_REQUEST_NS;
 
   while (currentEnd < end) {
-    ranges.push([currentStart, currentEnd]);
+    ranges.push([String(currentStart), String(currentEnd)]);
     currentStart = currentEnd;
-    currentEnd = currentEnd + MAX_RANGE_REQUEST;
+    currentEnd = currentEnd + MAX_RANGE_REQUEST_NS;
   }
 
-  ranges.push([currentStart, end]);
+  ranges.push([String(currentStart), String(end)]);
 
   return ranges;
 };
 
 export const executeHistogramQuery = ({
   query,
-  start,
-  end,
+  startNs,
+  endNs,
   interval,
   config,
   tenant,
@@ -242,18 +242,18 @@ export const executeHistogramQuery = ({
 
   const params = {
     query: histogramQuery,
-    start: String(start * 1000000),
-    end: String(end * 1000000),
+    start: startNs,
+    end: endNs,
     step: intervalString,
   };
 
   const { endpoint, requestInit } = getFetchConfig({ config, tenant });
 
-  const timeRange = end - start;
+  const timeRangeNs = BigInt(endNs) - BigInt(startNs);
 
   // for large time ranges, split the query into multiple smaller queries
-  if (timeRange > MAX_RANGE_REQUEST) {
-    const ranges = splitQueryRange(start, end);
+  if (timeRangeNs > MAX_RANGE_REQUEST_NS) {
+    const ranges = splitQueryRange(startNs, endNs);
 
     const queries: Array<CancellableFetch<QueryRangeResponse<MatrixResult>>> = [];
 
@@ -261,8 +261,8 @@ export const executeHistogramQuery = ({
       const [rangeStart, rangeEnd] = range;
       const rangeParams = {
         ...params,
-        start: String(rangeStart * 1000000),
-        end: String(rangeEnd * 1000000),
+        start: rangeStart,
+        end: rangeEnd,
       };
       const subQuery = cancellableFetch<QueryRangeResponse<MatrixResult>>(
         `${endpoint}/loki/api/v1/query_range?${new URLSearchParams(rangeParams)}`,
@@ -312,6 +312,7 @@ export const executeHistogramQuery = ({
 
 export const connectToTailSocket = ({
   query,
+  startNs,
   config,
   tenant,
   namespace,
@@ -323,10 +324,14 @@ export const connectToTailSocket = ({
     schema,
   });
 
-  const params = {
+  const params: Record<string, string> = {
     query: extendedQuery,
     limit: String(config?.logsLimit ?? 200),
   };
+
+  if (startNs) {
+    params.start = startNs;
+  }
 
   const { endpoint } = getFetchConfig({ config, tenant });
 

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -19,8 +19,8 @@ const LOKI_ENDPOINT = '/api/proxy/plugin/logging-view-plugin/backend';
 
 type QueryRangeParams = {
   query: string;
-  start: number;
-  end: number;
+  start: string;
+  end: string;
   config?: Config;
   namespace?: string;
   tenant: string;
@@ -155,8 +155,8 @@ export const executeQueryRange = ({
 
   const params: Record<string, string> = {
     query: extendedQuery,
-    start: String(start * 1000000),
-    end: String(end * 1000000),
+    start,
+    end,
     limit: String(config?.logsLimit ?? 100),
   };
 

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -123,7 +123,7 @@ const LogsDetailPage: FC<LogsDetailPageProps> = ({
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: number) => {
+  const handleLoadMoreData = (lastTimestamp: string) => {
     if (!isLoadingMoreLogsData) {
       getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
     }

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -123,9 +123,9 @@ const LogsDetailPage: FC<LogsDetailPageProps> = ({
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: string) => {
+  const handleLoadMoreData = (lastTimestampNs: string) => {
     if (!isLoadingMoreLogsData) {
-      getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
+      getMoreLogs({ lastTimestampNs, query, namespace, direction, schema });
     }
   };
 

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -98,9 +98,9 @@ const LogsDevPage: FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => {
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: string) => {
+  const handleLoadMoreData = (lastTimestampNs: string) => {
     if (!isLoadingMoreLogsData) {
-      getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
+      getMoreLogs({ lastTimestampNs, query, namespace, direction, schema });
     }
   };
 

--- a/web/src/pages/logs-dev-page.tsx
+++ b/web/src/pages/logs-dev-page.tsx
@@ -98,7 +98,7 @@ const LogsDevPage: FC<LogsDevPageProps> = ({ ns: namespaceFromProps }) => {
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: number) => {
+  const handleLoadMoreData = (lastTimestamp: string) => {
     if (!isLoadingMoreLogsData) {
       getMoreLogs({ lastTimestamp, query, namespace, direction, schema });
     }

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -91,9 +91,9 @@ const LogsPage: FC = () => {
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: string) => {
+  const handleLoadMoreData = (lastTimestampNs: string) => {
     if (!isLoadingMoreLogsData) {
-      getMoreLogs({ lastTimestamp, query, direction, schema });
+      getMoreLogs({ lastTimestampNs, query, direction, schema });
     }
   };
 

--- a/web/src/pages/logs-page.tsx
+++ b/web/src/pages/logs-page.tsx
@@ -91,7 +91,7 @@ const LogsPage: FC = () => {
     toggleStreaming({ query, schema });
   };
 
-  const handleLoadMoreData = (lastTimestamp: number) => {
+  const handleLoadMoreData = (lastTimestamp: string) => {
     if (!isLoadingMoreLogsData) {
       getMoreLogs({ lastTimestamp, query, direction, schema });
     }

--- a/web/src/value-utils.ts
+++ b/web/src/value-utils.ts
@@ -68,6 +68,8 @@ export const millisecondsFromDuration = (duration: string): number => {
   }
 };
 
+export const msToNs = (ms: number): string => String(BigInt(Math.round(ms)) * 1_000_000n);
+
 export const padLeadingZero = (value: number, length = 2): string =>
   String(value).padStart(length, '0');
 


### PR DESCRIPTION
This PR adjust the time resolution when loading more logs to use nanoseconds. This will avoid gaps for large volume of logs that have similar, or equal timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized timestamp handling for log loading, time-window queries, and pagination across the logs interface (including volume and histogram ranges).
  * Updated “Load more” to continue from the exact timestamp of the last displayed log entry.
  * Improved tailing behavior to align its start position with the requested timestamp.
* **Bug Fixes**
  * Resolved potential mismatches in the time windows used to fetch additional logs and analytics.
* **Tests**
  * Added unit tests for millisecond-to-nanosecond timestamp conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->