### PR TITLE
OU-1416,OU-1415: fix histogram and table colors themes, fix volume legend background

### DIFF
--- a/web/cypress/e2e/integration/logs-dev-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-dev-page.cy.ts
@@ -134,7 +134,9 @@ describe('Logs Dev Page', () => {
         cy.contains(TEST_MESSAGE);
       });
 
-    cy.byTestID(TestIds.SeverityDropdown).click();
+    cy.byTestID(TestIds.SeverityDropdown).within(() => {
+      cy.get('button').should('not.be.disabled').click();
+    });
     cy.contains('warning').click();
 
     cy.get('@queryRangeStreams.all').should('have.length.at.least', 1);

--- a/web/cypress/e2e/integration/logs-dev-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-dev-page.cy.ts
@@ -372,7 +372,7 @@ describe('Logs Dev Page', () => {
     cy.byTestID(TestIds.ShowQueryToggle).click();
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
-      cy.get('textarea').clear().type('{ job = "some_job" }', {
+      cy.get('textarea').type('{selectAll}').type('{backspace}').type('{ job = "some_job" }', {
         parseSpecialCharSequences: false,
       });
     });
@@ -423,7 +423,8 @@ describe('Logs Dev Page', () => {
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
       cy.get('textarea')
-        .clear()
+        .type('{selectAll}')
+        .type('{backspace}')
         .type(
           'sum by (level) (count_over_time({ kubernetes_namespace_name="my-namespace" })[10m])',
           {
@@ -441,9 +442,12 @@ describe('Logs Dev Page', () => {
     cy.byTestID(TestIds.LogsHistogram).should('not.exist');
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
-      cy.get('textarea').clear().type('{ kubernetes_namespace_name="my-namespace" }', {
-        parseSpecialCharSequences: false,
-      });
+      cy.get('textarea')
+        .type('{selectAll}')
+        .type('{backspace}')
+        .type('{ kubernetes_namespace_name="my-namespace" }', {
+          parseSpecialCharSequences: false,
+        });
     });
 
     cy.byTestID(TestIds.ExecuteQueryButton).click({ force: true });

--- a/web/cypress/e2e/integration/logs-dev-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-dev-page.cy.ts
@@ -405,7 +405,9 @@ describe('Logs Dev Page', () => {
       QUERY_RANGE_STREAMS_URL_MATCH,
       queryRangeStreamsValidResponse({ message: TEST_MESSAGE }),
     );
-    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse());
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse()).as(
+      'queryRangeMatrix',
+    );
 
     cy.visit(LOGS_DEV_PAGE_URL);
 
@@ -432,6 +434,8 @@ describe('Logs Dev Page', () => {
     });
 
     cy.byTestID(TestIds.ExecuteQueryButton).click({ force: true });
+
+    cy.wait('@queryRangeMatrix');
 
     cy.byTestID(TestIds.LogsMetrics).should('exist');
     cy.byTestID(TestIds.ToggleHistogramButton).should('be.disabled');

--- a/web/cypress/e2e/integration/logs-dev-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-dev-page.cy.ts
@@ -372,7 +372,7 @@ describe('Logs Dev Page', () => {
     cy.byTestID(TestIds.ShowQueryToggle).click();
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
-      cy.get('textarea').type('{selectAll}').type('{backspace}').type('{ job = "some_job" }', {
+      cy.get('textarea').clear().type('{ job = "some_job" }', {
         parseSpecialCharSequences: false,
       });
     });
@@ -423,8 +423,7 @@ describe('Logs Dev Page', () => {
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
       cy.get('textarea')
-        .type('{selectAll}')
-        .type('{backspace}')
+        .clear()
         .type(
           'sum by (level) (count_over_time({ kubernetes_namespace_name="my-namespace" })[10m])',
           {
@@ -442,15 +441,12 @@ describe('Logs Dev Page', () => {
     cy.byTestID(TestIds.LogsHistogram).should('not.exist');
 
     cy.byTestID(TestIds.LogsQueryInput).within(() => {
-      cy.get('textarea')
-        .type('{selectAll}')
-        .type('{backspace}')
-        .type('{ kubernetes_namespace_name="my-namespace" }', {
-          parseSpecialCharSequences: false,
-        });
+      cy.get('textarea').clear().type('{ kubernetes_namespace_name="my-namespace" }', {
+        parseSpecialCharSequences: false,
+      });
     });
 
-    cy.byTestID(TestIds.ExecuteQueryButton).click();
+    cy.byTestID(TestIds.ExecuteQueryButton).click({ force: true });
     cy.byTestID(TestIds.LogsMetrics).should('not.exist');
     cy.byTestID(TestIds.ToggleHistogramButton).should('be.enabled');
     cy.byTestID(TestIds.ToggleHistogramButton).click();

--- a/web/cypress/e2e/integration/logs-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-page.cy.ts
@@ -278,6 +278,8 @@ describe('Logs Page', () => {
     cy.contains('infrastructure').click();
     cy.wait(50); // Wait for frontend to update after clicking
 
+    cy.wait('@queryRangeStreamsInfrastructure');
+
     cy.byTestID(TestIds.ExecuteQueryButton).click();
 
     cy.byTestID(TestIds.LogsHistogram)

--- a/web/src/components/logs-metrics.css
+++ b/web/src/components/logs-metrics.css
@@ -3,3 +3,7 @@
   height: 10px;
   margin-right: 5px;
 }
+
+.lv-plugin__metrics-legend-table .pf-v6-c-table__sticky-cell {
+  --pf-v6-c-table__sticky-cell--BackgroundColor: transparent;
+}

--- a/web/src/components/logs-metrics.tsx
+++ b/web/src/components/logs-metrics.tsx
@@ -228,7 +228,11 @@ export const LogsMetrics: FC<LogsMetricsProps> = ({
           </Chart>
           {displayLegendTable && (
             <InnerScrollContainer>
-              <Table variant="compact" aria-label="alert metrics">
+              <Table
+                variant="compact"
+                aria-label="alert metrics"
+                className="lv-plugin__metrics-legend-table"
+              >
                 <Thead>
                   <Tr>
                     <Th isStickyColumn stickyMinWidth="20px" style={{ width: '20px' }}></Th>

--- a/web/src/components/logs-table.css
+++ b/web/src/components/logs-table.css
@@ -51,7 +51,7 @@
   bottom: 3px;
   width: 3px;
   left: 3px;
-  background-color: var(--pf-t--global--text--color--disabled);
+  background-color: var(--lv-severity-color, var(--pf-t--global--text--color--disabled));
 }
 
 .lv-plugin__table__row--expanded::before {
@@ -60,30 +60,6 @@
 
 .lv-plugin__table__row--expanded-details::before {
   top: 0;
-}
-
-.lv-plugin__table__severity-critical::before {
-  background-color: var(--pf-t--global--text--color--status--info--default);
-}
-
-.lv-plugin__table__severity-error::before {
-  background-color: var(--pf-t--global--icon--color--status--danger--default);
-}
-
-.lv-plugin__table__severity-warning::before {
-  background-color: var(--pf-t--global--icon--color--status--warning--default);
-}
-
-.lv-plugin__table__severity-info::before {
-  background-color: var(--pf-t--global--color--status--success--default);
-}
-
-.lv-plugin__table__severity-debug::before {
-  background-color: var(--pf-t--global--color--brand--default);
-}
-
-.lv-plugin__table__severity-trace::before {
-  background-color: var(--pf-t--global--text--color--status--custom--default);
 }
 
 .lv-plugin__table__row-info {

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -4,6 +4,7 @@ import { Split, SplitItem } from '@patternfly/react-core';
 import { ISortBy, SortByDirection, Td, ThProps } from '@patternfly/react-table';
 import {
   Children,
+  CSSProperties,
   FC,
   MouseEvent,
   MutableRefObject,
@@ -26,7 +27,7 @@ import {
   StreamLogData,
 } from '../logs.types';
 import { parseName, parseResources, ResourceLabel } from '../parse-resources';
-import { severityFromString } from '../severity';
+import { getSeverityColor, Severity, severityFromString } from '../severity';
 import { numericComparator, bigIntDifference } from '../sort-utils';
 import { TestIds } from '../test-ids';
 import { LogDetail } from './log-detail';
@@ -113,8 +114,11 @@ const aggregateStreamLogData = (
   return [];
 };
 
-const getSeverityClass = (severity: string) => {
-  return severity ? `lv-plugin__table__severity-${severity}` : '';
+const getRowSeverityStyle = (severity: string): CSSProperties => {
+  if (!severity) {
+    return {};
+  }
+  return { '--lv-severity-color': getSeverityColor(severity as Severity) } as CSSProperties;
 };
 
 const columns: Array<TableColumn<LogTableData>> = [
@@ -385,8 +389,13 @@ export const LogsTable: FC<PropsWithChildren<LogsTableProps>> = ({
           ? 'lv-plugin__table__row--expanded'
           : 'lv-plugin__table__row--expanded-details';
     }
-    return `lv-plugin__table__row ${getSeverityClass(row.severity)} ${expandedClass}`;
+    return `lv-plugin__table__row ${expandedClass}`;
   }, []);
+
+  const getRowStyle = useCallback(
+    (row: LogTableData): CSSProperties => getRowSeverityStyle(row.severity),
+    [],
+  );
 
   return (
     <div data-test={TestIds.LogsTable} className="lv-plugin__table">
@@ -399,6 +408,7 @@ export const LogsTable: FC<PropsWithChildren<LogsTableProps>> = ({
         columns={columns}
         getSortParams={getSortParams}
         getRowClassName={getRowClassName}
+        getRowStyle={getRowStyle}
         error={error}
         isLoading={isLoading}
         isStreaming={isStreaming}

--- a/web/src/components/logs-table.tsx
+++ b/web/src/components/logs-table.tsx
@@ -4,7 +4,6 @@ import { Split, SplitItem } from '@patternfly/react-core';
 import { ISortBy, SortByDirection, Td, ThProps } from '@patternfly/react-table';
 import {
   Children,
-  CSSProperties,
   FC,
   MouseEvent,
   MutableRefObject,
@@ -27,7 +26,7 @@ import {
   StreamLogData,
 } from '../logs.types';
 import { parseName, parseResources, ResourceLabel } from '../parse-resources';
-import { getSeverityColor, Severity, severityFromString } from '../severity';
+import { severityFromString } from '../severity';
 import { numericComparator, bigIntDifference } from '../sort-utils';
 import { TestIds } from '../test-ids';
 import { LogDetail } from './log-detail';
@@ -112,13 +111,6 @@ const aggregateStreamLogData = (
   }
 
   return [];
-};
-
-const getRowSeverityStyle = (severity: string): CSSProperties => {
-  if (!severity) {
-    return {};
-  }
-  return { '--lv-severity-color': getSeverityColor(severity as Severity) } as CSSProperties;
 };
 
 const columns: Array<TableColumn<LogTableData>> = [
@@ -392,11 +384,6 @@ export const LogsTable: FC<PropsWithChildren<LogsTableProps>> = ({
     return `lv-plugin__table__row ${expandedClass}`;
   }, []);
 
-  const getRowStyle = useCallback(
-    (row: LogTableData): CSSProperties => getRowSeverityStyle(row.severity),
-    [],
-  );
-
   return (
     <div data-test={TestIds.LogsTable} className="lv-plugin__table">
       {showStats && <StatsTable logsData={logsData} />}
@@ -408,7 +395,6 @@ export const LogsTable: FC<PropsWithChildren<LogsTableProps>> = ({
         columns={columns}
         getSortParams={getSortParams}
         getRowClassName={getRowClassName}
-        getRowStyle={getRowStyle}
         error={error}
         isLoading={isLoading}
         isStreaming={isStreaming}

--- a/web/src/components/virtualized-logs-table.tsx
+++ b/web/src/components/virtualized-logs-table.tsx
@@ -26,6 +26,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LogTableData, Schema } from '../logs.types';
+import { getSeverityColor, Severity } from '../severity';
 import { CenteredContainer } from './centered-container';
 import { ErrorMessage } from './error-message';
 
@@ -39,7 +40,6 @@ interface VirtualizedLogsTableProps<D> {
   isLoading?: boolean;
   dataIsEmpty?: boolean;
   getRowClassName?: (obj: D) => string;
-  getRowStyle?: (obj: D) => React.CSSProperties;
   hasMoreLogsData?: boolean;
   isLoadingMore?: boolean;
   onLoadMore?: () => void;
@@ -100,6 +100,13 @@ export const TableData: FC<PropsWithChildren<TableDataProps>> = ({
   ) : null;
 TableData.displayName = 'TableData';
 
+const getRowSeverityStyle = (severity: string): CSSProperties => {
+  if (!severity) {
+    return {};
+  }
+  return { '--lv-severity-color': getSeverityColor(severity as Severity) } as CSSProperties;
+};
+
 type VirtualizedTableBodyProps<D, R = unknown> = {
   Row: ComponentType<RowProps<D, R>>;
   data: D[];
@@ -113,7 +120,6 @@ type VirtualizedTableBodyProps<D, R = unknown> = {
   getRowId?: (obj: D) => string;
   getRowTitle?: (obj: D) => string;
   getRowClassName?: (obj: D) => string;
-  getRowStyle?: (obj: D) => React.CSSProperties;
   scrollToIndex?: number;
   expandedItems?: Set<number>;
   showResources?: boolean;
@@ -151,7 +157,6 @@ const VirtualizedTableBody = ({
   getRowId,
   getRowTitle,
   getRowClassName,
-  getRowStyle,
   scrollToIndex,
   expandedItems,
   showResources,
@@ -220,7 +225,7 @@ const VirtualizedTableBody = ({
             id={getRowId?.(rowArgs.obj) ?? key}
             index={index}
             trKey={key}
-            style={{ ...style, ...getRowStyle?.(rowArgs.obj) }}
+            style={{ ...style, ...getRowSeverityStyle(rowArgs.obj.severity) }}
             title={getRowTitle?.(rowArgs.obj)}
             className={getRowClassName?.(rowArgs.obj)}
           >
@@ -294,7 +299,6 @@ export const VirtualizedLogsTable = ({
   columns,
   getSortParams,
   getRowClassName,
-  getRowStyle,
   error,
   isStreaming,
   isLoading,
@@ -400,7 +404,6 @@ export const VirtualizedLogsTable = ({
                         scrollTop={scrollTop}
                         width={width}
                         getRowClassName={getRowClassName}
-                        getRowStyle={getRowStyle}
                         scrollToIndex={scrollToIndex}
                         expandedItems={expandedItems}
                         showResources={showResources}

--- a/web/src/components/virtualized-logs-table.tsx
+++ b/web/src/components/virtualized-logs-table.tsx
@@ -39,6 +39,7 @@ interface VirtualizedLogsTableProps<D> {
   isLoading?: boolean;
   dataIsEmpty?: boolean;
   getRowClassName?: (obj: D) => string;
+  getRowStyle?: (obj: D) => React.CSSProperties;
   hasMoreLogsData?: boolean;
   isLoadingMore?: boolean;
   onLoadMore?: () => void;
@@ -112,6 +113,7 @@ type VirtualizedTableBodyProps<D, R = unknown> = {
   getRowId?: (obj: D) => string;
   getRowTitle?: (obj: D) => string;
   getRowClassName?: (obj: D) => string;
+  getRowStyle?: (obj: D) => React.CSSProperties;
   scrollToIndex?: number;
   expandedItems?: Set<number>;
   showResources?: boolean;
@@ -149,6 +151,7 @@ const VirtualizedTableBody = ({
   getRowId,
   getRowTitle,
   getRowClassName,
+  getRowStyle,
   scrollToIndex,
   expandedItems,
   showResources,
@@ -217,7 +220,7 @@ const VirtualizedTableBody = ({
             id={getRowId?.(rowArgs.obj) ?? key}
             index={index}
             trKey={key}
-            style={style}
+            style={{ ...style, ...getRowStyle?.(rowArgs.obj) }}
             title={getRowTitle?.(rowArgs.obj)}
             className={getRowClassName?.(rowArgs.obj)}
           >
@@ -291,6 +294,7 @@ export const VirtualizedLogsTable = ({
   columns,
   getSortParams,
   getRowClassName,
+  getRowStyle,
   error,
   isStreaming,
   isLoading,
@@ -396,6 +400,7 @@ export const VirtualizedLogsTable = ({
                         scrollTop={scrollTop}
                         width={width}
                         getRowClassName={getRowClassName}
+                        getRowStyle={getRowStyle}
                         scrollToIndex={scrollToIndex}
                         expandedItems={expandedItems}
                         showResources={showResources}

--- a/web/src/severity.ts
+++ b/web/src/severity.ts
@@ -1,11 +1,3 @@
-import chartGrayColor from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
-import chartBlueColor from '@patternfly/react-tokens/dist/esm/chart_color_blue_200';
-import chartCyanColor from '@patternfly/react-tokens/dist/esm/chart_color_teal_200';
-import chartYellowColor from '@patternfly/react-tokens/dist/esm/chart_color_yellow_200';
-import chartGreenColor from '@patternfly/react-tokens/dist/esm/chart_color_green_200';
-import chartPurpleColor from '@patternfly/react-tokens/dist/esm/chart_color_purple_200';
-import chartRedColor from '@patternfly/react-tokens/dist/esm/chart_color_red_orange_100';
-
 export type Severity =
   | 'critical'
   | 'error'
@@ -44,26 +36,20 @@ export const isSeverity = (value: string): value is Severity =>
 
 export const getSeverityColor = (severity: Severity): string => {
   switch (severity) {
-    case 'critical':
-      return chartPurpleColor.value;
-      break;
-    case 'error':
-      return chartRedColor.value;
-      break;
-    case 'warning':
-      return chartYellowColor.value;
-      break;
+    case 'critical': // orange
+      return 'var(--pf-t--chart--global--warning--color--100)';
+    case 'error': // red
+      return 'var(--pf-t--chart--global--danger--color--100)';
+    case 'warning': // yellow
+      return 'var(--pf-t--chart--global--warning--color--200)';
     case 'info':
-      return chartGreenColor.value;
-      break;
+      return 'var(--pf-t--chart--color--purple--300)';
     case 'debug':
-      return chartBlueColor.value;
-      break;
+      return 'var(--pf-t--chart--color--blue--300)';
     case 'trace':
-      return chartCyanColor.value;
-      break;
-    default:
-      return chartGrayColor.value;
+      return 'var(--pf-t--chart--color--teal--300)';
+    default: // gray
+      return 'var(--pf-t--chart--color--black--300)';
   }
 };
 


### PR DESCRIPTION
### JIRA 
https://redhat.atlassian.net/browse/OU-1416
https://redhat.atlassian.net/browse/OU-1415

Note: Update chart colors associates to align with patternfly guidelines https://www.patternfly.org/ai/guidelines/color/#color-associations-and-statuses

### Image 
quay.io/jezhu/logging-view-plugin:ou1416-ou1415-jul17

### Screenshots 

Figure. Fix log volume legend background to be transparent ([OU-1416](https://redhat.atlassian.net/browse/OU-1416)) 
<img width="1473" height="874" alt="Screenshot 2026-07-16 at 5 51 09 PM" src="https://github.com/user-attachments/assets/cf5a029d-846d-43dc-ab3c-da07c7d30cc8" />
<img width="1268" height="844" alt="Screenshot 2026-07-17 at 4 35 24 PM" src="https://github.com/user-attachments/assets/a98fb663-cbb2-4ec3-848e-157b505d49f7" />



Figure. Fix histogram and table row colors to match ([OU-1415](https://redhat.atlassian.net/browse/OU-1415))  
<img width="1303" height="1193" alt="Screenshot 2026-07-17 at 4 05 37 PM" src="https://github.com/user-attachments/assets/dca03312-a1d4-4c46-ab6a-f3fdbb20a034" />
<img width="1293" height="995" alt="image" src="https://github.com/user-attachments/assets/f5b9c19e-fa48-41d6-8497-090053a48034" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated logs table row indicator coloring to use severity-driven CSS variables consistently, including with virtualized rendering.
  * Refined the metrics legend sticky-cell background for more consistent styling.

* **Accessibility**
  * Improved the metrics legend table by adding an `aria-label` and a dedicated styling class.

* **Tests**
  * Improved Logs page and Logs dev page E2E reliability with more dependable textarea editing and clearer network synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->