### PR TITLE
OCPBUGS-94073: fix: add json pipeline for viaq schema

### DIFF
--- a/web/src/__tests__/attribute-filters.spec.ts
+++ b/web/src/__tests__/attribute-filters.spec.ts
@@ -489,7 +489,7 @@ describe('Attribute filters', () => {
         filters: {
           pod: new Set(['.*etcd.*']),
         },
-        expectedQuery: '{ kubernetes_pod_name=~".*etcd.*" }',
+        expectedQuery: '{ kubernetes_pod_name=~".*etcd.*" } | json',
       },
       {
         initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" }',
@@ -498,17 +498,17 @@ describe('Attribute filters', () => {
         filters: {
           pod: new Set(['openshift.pod']),
         },
-        expectedQuery: '{ kubernetes_pod_name="openshift.pod" }',
+        expectedQuery: '{ kubernetes_pod_name="openshift.pod" } | json',
       },
       {
-        initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" }',
+        initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" } | json',
         // A regex including a dot must have a quantifier (* or + or ?)
         // as regex match in LogQL is fully anchored
         // https://grafana.com/docs/loki/latest/query/log_queries/#log-stream-selector
         filters: {
           pod: new Set(['openshift.*pod']),
         },
-        expectedQuery: '{ kubernetes_pod_name=~"openshift.*pod" }',
+        expectedQuery: '{ kubernetes_pod_name=~"openshift.*pod" } | json',
       },
       {
         initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" }',
@@ -518,7 +518,7 @@ describe('Attribute filters', () => {
         filters: {
           pod: new Set(['openshift.+pod']),
         },
-        expectedQuery: '{ kubernetes_pod_name=~"openshift.+pod" }',
+        expectedQuery: '{ kubernetes_pod_name=~"openshift.+pod" } | json',
       },
       {
         initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" }',
@@ -528,14 +528,14 @@ describe('Attribute filters', () => {
         filters: {
           pod: new Set(['openshift.?pod']),
         },
-        expectedQuery: '{ kubernetes_pod_name=~"openshift.?pod" }',
+        expectedQuery: '{ kubernetes_pod_name=~"openshift.?pod" } | json',
       },
       {
         initialQuery: '{ kubernetes_pod_name=~"a-pod|b-pod" }',
         filters: {
           pod: new Set(['ns-1']),
         },
-        expectedQuery: '{ kubernetes_pod_name="ns-1" }',
+        expectedQuery: '{ kubernetes_pod_name="ns-1" } | json',
       },
       {
         initialQuery:
@@ -553,27 +553,28 @@ describe('Attribute filters', () => {
       },
       {
         initialQuery:
-          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
+          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } | json |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
         filters: {},
-        expectedQuery: '{ label="test" } | other="filter"',
+        expectedQuery: '{ label="test" } | json | other="filter"',
       },
       {
         initialQuery:
-          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
+          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } | json |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
         filters: {
           namespace: new Set(['namespace-3']),
         },
-        expectedQuery: '{ kubernetes_namespace_name="namespace-3", label="test" } | other="filter"',
+        expectedQuery:
+          '{ kubernetes_namespace_name="namespace-3", label="test" } | json | other="filter"',
       },
       {
         initialQuery:
-          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
+          '{ kubernetes_pod_name=~"a-pod|b-pod", kubernetes_namespace_name=~"ns-1|ns-2", label="test", kubernetes_container_name="container-1" } | json |="some line content" | other="filter" | level="err|eror" or level="unknown" or level=""',
         filters: {
           namespace: new Set(['namespace-3', 'namespace-4']),
           severity: new Set(['unknown', 'error']),
         },
         expectedQuery:
-          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | other="filter" | level="unknown" or level="" or level=~"error|err|eror"',
+          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | json | other="filter" | level="unknown" or level="" or level=~"error|err|eror"',
       },
       {
         initialQuery:
@@ -584,7 +585,7 @@ describe('Attribute filters', () => {
           severity: new Set(['error', 'unknown']),
         },
         expectedQuery:
-          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | other="filter" | level="unknown" or level="" or level=~"error|err|eror"',
+          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | json | other="filter" | level="unknown" or level="" or level=~"error|err|eror"',
       },
       {
         initialQuery:
@@ -595,7 +596,7 @@ describe('Attribute filters', () => {
           severity: new Set(['error']),
         },
         expectedQuery:
-          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | other="filter" | level=~"error|err|eror"',
+          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | json | other="filter" | level=~"error|err|eror"',
       },
       {
         initialQuery:
@@ -607,7 +608,7 @@ describe('Attribute filters', () => {
           pod: new Set(['some-pod']),
         },
         expectedQuery:
-          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | other="filter" | level=~"error|err|eror|info|inf|information|notice"',
+          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | json | other="filter" | level=~"error|err|eror|info|inf|information|notice"',
       },
       {
         initialQuery:
@@ -619,7 +620,7 @@ describe('Attribute filters', () => {
           pod: new Set(['some-pod']),
         },
         expectedQuery:
-          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | other="filter"',
+          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } |= `new line filter` | json | other="filter"',
       },
       {
         initialQuery:
@@ -631,7 +632,7 @@ describe('Attribute filters', () => {
           pod: new Set(['some-pod']),
         },
         expectedQuery:
-          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | other="filter"',
+          '{ kubernetes_pod_name="some-pod", kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | json | other="filter"',
       },
       {
         initialQuery:
@@ -643,7 +644,7 @@ describe('Attribute filters', () => {
           pod: new Set<string>(),
         },
         expectedQuery:
-          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | other="filter"',
+          '{ kubernetes_namespace_name=~"namespace-3|namespace-4", label="test" } | json | other="filter"',
       },
       // Add otel labels keeping the viaq labels
       {

--- a/web/src/__tests__/logql-query.spec.ts
+++ b/web/src/__tests__/logql-query.spec.ts
@@ -436,7 +436,7 @@ describe('LogQL query', () => {
         expected: '{ foo="var" } | json | level="err|error"',
       },
       {
-        query: '{ foo="var" } | json |= "line search"',
+        query: '{ foo="var" } |= "line search" | json',
         pipeline: { operator: '|=' },
         matchOptions: { matchLabel: 'non-match-label' },
         expected: '{ foo="var" } | json',
@@ -464,20 +464,20 @@ describe('LogQL query', () => {
         expected: 'max_over_time({ logs_type=~".+" }[10m]))',
       },
       {
-        query: '{ foo="var" } | json |= "line search"',
-        expected: '{ foo="var" } | json |= "line search"',
+        query: '{ foo="var" } |= "line search" | json',
+        expected: '{ foo="var" } |= "line search" | json',
       },
       {
-        query: '{ foo= } | json |= "line search"',
-        expected: '{ foo= } | json |= "line search"',
+        query: '{ foo= } |= "line search" | json',
+        expected: '{ foo= } |= "line search" | json',
       },
       {
         query: '{ foo="bar" } | json "line search"',
         expected: '{ foo="bar" } | json "line search"',
       },
       {
-        query: '{ foo } | json |= "line search"',
-        expected: '{ foo } | json |= "line search"',
+        query: '{ foo } |= "line search" | json',
+        expected: '{ foo } |= "line search" | json',
       },
       {
         query: '{ foo="var" } | unknown',
@@ -509,15 +509,15 @@ describe('LogQL query', () => {
       },
       {
         query:
-          '{ log_type=~".+" } | json != "tekton" |= "TLS handshake error from 10." != "10.128"',
+          '{ log_type=~".+" } != "tekton" |= "TLS handshake error from 10." | json != "10.128"',
         expected:
-          '{ log_type=~".+" } | json != "tekton" |= "TLS handshake error from 10." != "10.128"',
+          '{ log_type=~".+" } != "tekton" |= "TLS handshake error from 10." != "10.128" | json',
       },
       {
         query:
           '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128"',
         expected:
-          '{ log_type=~".+" } | json | level="unknown" or level="" != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128"',
+          '{ log_type=~".+" } != "tekton" |= "TLS handshake error from 10." !~ "10.128" |~ "10.128" | json | level="unknown" or level=""',
       },
       {
         query: '{ app="foobar" } |> "I <_>" | json',
@@ -526,6 +526,10 @@ describe('LogQL query', () => {
       {
         query: '{ app="foobar" } !> "I <_>" | json',
         expected: '{ app="foobar" } !> "I <_>" | json',
+      },
+      {
+        query: '{ app="x" } | line_format "{{.message}}" |= "error"',
+        expected: '{ app="x" } | line_format "{{.message}}" |= "error"',
       },
     ].forEach(({ query, expected }) => {
       const logql = new LogQLQuery(query);

--- a/web/src/attribute-filters.tsx
+++ b/web/src/attribute-filters.tsx
@@ -548,14 +548,12 @@ export const queryFromFilters = ({
   attributes,
   tenant,
   schema,
-  addJSONParser,
 }: {
   existingQuery: string;
   filters?: Filters;
   attributes: AttributeList;
   tenant?: string;
   schema: Schema;
-  addJSONParser?: boolean;
 }): string => {
   const query = new LogQLQuery(existingQuery);
 
@@ -617,8 +615,8 @@ export const queryFromFilters = ({
     query.removeSelectorMatcher({ label: tenantLabel });
   }
 
-  if (schema === Schema.viaq && !!addJSONParser) {
-    query.addPipelineStage({ operator: '| json' }, { placement: 'start' });
+  if (schema === Schema.viaq) {
+    query.addPipelineStage({ operator: '|', value: 'json' }, { placement: 'start' });
   }
 
   return query.toString();

--- a/web/src/hooks/useURLState.ts
+++ b/web/src/hooks/useURLState.ts
@@ -50,10 +50,7 @@ export const defaultQueryFromTenant = ({
   schema: Schema;
 }) => {
   const logType = ResourceToStreamLabels[ResourceLabel.LogType];
-  if (schema === Schema.otel) {
-    return `{ ${logType.otel}="${tenant}" }`;
-  }
-  return `{ ${logType.viaq}="${tenant}" } | json`;
+  return `{ ${schema === Schema.otel ? logType.otel : logType.viaq}="${tenant}" }${schema === Schema.viaq ? ' | json' : ''}`;
 };
 
 const getDirectionValue = (value?: string | null): Direction =>
@@ -153,7 +150,6 @@ export const useURLState = ({
         attributes,
         tenant,
         schema: selectedSchema,
-        addJSONParser: true,
       });
       newQueryParams.set(QUERY_PARAM_KEY, newQuery);
 

--- a/web/src/logql-query.ts
+++ b/web/src/logql-query.ts
@@ -143,6 +143,48 @@ const parsePipelineStages = (
   return pipelineStages;
 };
 
+// place line filters first for better performance
+const operatorSort = (a: PipelineStage, b: PipelineStage) => {
+  const lineFilterOperators = ['|=', '!=', '|~', '!~'];
+
+  if (
+    lineFilterOperators.includes(a.operator ?? '') &&
+    !lineFilterOperators.includes(b.operator ?? '')
+  ) {
+    return -1;
+  } else if (
+    !lineFilterOperators.includes(a.operator ?? '') &&
+    lineFilterOperators.includes(b.operator ?? '')
+  ) {
+    return 1;
+  }
+
+  return 0;
+};
+
+const isLineTransformStage = (stage: PipelineStage): boolean => {
+  return stage.value?.startsWith('line_format') ?? false;
+};
+
+const sortPipelineWithBoundaries = (pipeline: Array<PipelineStage>): Array<PipelineStage> => {
+  const result: Array<PipelineStage> = [];
+  let segment: Array<PipelineStage> = [];
+
+  for (const stage of pipeline) {
+    if (isLineTransformStage(stage)) {
+      result.push(...segment.sort(operatorSort));
+      result.push(stage);
+      segment = [];
+    } else {
+      segment.push(stage);
+    }
+  }
+
+  result.push(...segment.sort(operatorSort));
+
+  return result;
+};
+
 export class LogQLQuery {
   streamSelector: Array<LabelMatcher> = [];
   pipeline: Array<PipelineStage> = [];
@@ -295,7 +337,7 @@ export class LogQLQuery {
 
     const pipeline =
       this.streamSelector.length > 0
-        ? `${this.pipeline
+        ? `${sortPipelineWithBoundaries(this.pipeline)
             .map(({ operator, value }) => ` ${operator} ${value !== undefined ? value : ''}`)
             .join('')}`
         : '';

--- a/web/src/pages/logs-detail-page.tsx
+++ b/web/src/pages/logs-detail-page.tsx
@@ -106,7 +106,7 @@ const LogsDetailPage: FC<LogsDetailPageProps> = ({
       const labelMatchers = getStreamLabelsFromSchema(s);
       const podLabel = labelMatchers[ResourceLabel.Pod];
 
-      return `{ ${podLabel} = "${podname}" }${s == Schema.viaq ? ' | json' : ''}`;
+      return `{ ${podLabel} = "${podname}" } ${s == Schema.viaq ? '| json' : ''}`;
     },
     getAttributes: ({ config: c, schema: s }) => {
       if (namespace && podname) {


### PR DESCRIPTION
- Adds the `| json` pipeline stage to all queries when the schema is viaq
- Sorts the line filters first for better query performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic log query generation for Viaq data, including consistent JSON parsing.
  - Ensured line filters appear before JSON parsing and other pipeline stages for more reliable query behavior.
  - Preserved valid query text when selectors are reordered or incomplete.
  - Corrected default queries when switching schemas and selecting streams.
- **Tests**
  - Expanded coverage for regex, namespace, content, severity, empty filters, and complex query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->