### PR TITLE
OU-946: use console fetch to include impersonation headers

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -7,5 +7,8 @@ module.exports = {
     '^.+\\.js$': 'ts-jest',
   },
   transformIgnorePatterns: ['node_modules/(?!(@openshift-console|@patternfly))'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.js',
+  },
   coverageDirectory: '<rootDir>/coverage/cov-jest',
 };

--- a/web/mockModules/dummy.tsx
+++ b/web/mockModules/dummy.tsx
@@ -4,3 +4,70 @@ export { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/w
 export const useK8sWatchResource = () => [null, true, ''];
 export const useActivePerspective = () => ['admin'];
 export const useAccessReview = () => [true, false];
+
+const fetchJSON = async (url: string, method = 'GET', options?: RequestInit, timeout?: number) => {
+  const controller = options?.signal ? undefined : new AbortController();
+  const signal = options?.signal ?? controller?.signal;
+
+  const timeoutId =
+    timeout && timeout > 0 && controller
+      ? setTimeout(() => controller.abort(), timeout)
+      : undefined;
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      method,
+      headers: {
+        ...options?.headers,
+        Accept: 'application/json',
+      },
+      signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      const error = new Error(text) as Error & { response: { status: number } };
+      error.response = { status: response.status };
+      throw error;
+    }
+
+    return response.json();
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
+
+fetchJSON.post = async (url: string, json: unknown, options?: RequestInit, timeout?: number) =>
+  fetchJSON(
+    url,
+    'POST',
+    { ...options, body: typeof json === 'string' ? json : JSON.stringify(json) },
+    timeout,
+  );
+
+fetchJSON.delete = async (url: string, json: unknown, options?: RequestInit, timeout?: number) =>
+  fetchJSON(
+    url,
+    'DELETE',
+    { ...options, body: typeof json === 'string' ? json : JSON.stringify(json) },
+    timeout,
+  );
+
+fetchJSON.put = async (url: string, json: unknown, options?: RequestInit, timeout?: number) =>
+  fetchJSON(
+    url,
+    'PUT',
+    { ...options, body: typeof json === 'string' ? json : JSON.stringify(json) },
+    timeout,
+  );
+
+fetchJSON.patch = async (url: string, json: unknown, options?: RequestInit, timeout?: number) =>
+  fetchJSON(
+    url,
+    'PATCH',
+    { ...options, body: typeof json === 'string' ? json : JSON.stringify(json) },
+    timeout,
+  );
+
+export const consoleFetchJSON = fetchJSON;

--- a/web/src/__mocks__/styleMock.js
+++ b/web/src/__mocks__/styleMock.js
@@ -1,0 +1,2 @@
+/* global module */
+module.exports = {};

--- a/web/src/__tests__/attribute-filters.spec.ts
+++ b/web/src/__tests__/attribute-filters.spec.ts
@@ -1,3 +1,8 @@
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  consoleFetchJSON: jest.fn(),
+  K8sResourceCommon: {},
+}));
+
 import {
   filtersFromQuery,
   getContentPipelineStage,

--- a/web/src/__tests__/cancellable-fetch.spec.ts
+++ b/web/src/__tests__/cancellable-fetch.spec.ts
@@ -1,0 +1,133 @@
+const mockConsoleFetch = jest.fn();
+const mockPost = jest.fn();
+
+// Properly type the mock
+Object.assign(mockConsoleFetch, {
+  post: mockPost,
+});
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  consoleFetchJSON: mockConsoleFetch,
+}));
+
+import { cancellableFetch, isFetchError } from '../cancellable-fetch';
+
+describe('cancellableFetch with consoleFetchJSON', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should make a GET request using consoleFetchJSON', async () => {
+    const mockResponse = { data: 'test' };
+    mockConsoleFetch.mockResolvedValue(mockResponse);
+
+    const { request } = cancellableFetch('https://example.com');
+    const result = await request();
+
+    expect(result).toEqual(mockResponse);
+    expect(mockConsoleFetch).toHaveBeenCalledWith(
+      'https://example.com',
+      'GET',
+      { signal: expect.any(AbortSignal) },
+      30000,
+    );
+  });
+
+  it('should make a POST request using consoleFetchJSON.post', async () => {
+    const mockResponse = { data: 'test' };
+    mockPost.mockResolvedValue(mockResponse);
+
+    const { request } = cancellableFetch(
+      'https://example.com',
+      {
+        method: 'POST',
+        body: JSON.stringify({ test: 'data' }),
+      },
+      5000,
+    );
+    await request();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      'https://example.com',
+      JSON.stringify({ test: 'data' }),
+      {
+        method: 'POST',
+        body: JSON.stringify({ test: 'data' }),
+        signal: expect.any(AbortSignal),
+      },
+      5000,
+    );
+  });
+
+  it('should handle timeout configuration', async () => {
+    const mockResponse = { data: 'test' };
+    mockConsoleFetch.mockResolvedValue(mockResponse);
+
+    const { request } = cancellableFetch('https://example.com', undefined, 5000);
+    await request();
+
+    expect(mockConsoleFetch).toHaveBeenCalledWith(
+      'https://example.com',
+      'GET',
+      { signal: expect.any(AbortSignal) },
+      5000,
+    );
+  });
+
+  it('should disable timeout when timeout is 0', async () => {
+    const mockResponse = { data: 'test' };
+    mockConsoleFetch.mockResolvedValue(mockResponse);
+
+    const { request } = cancellableFetch('https://example.com', undefined, 0);
+    await request();
+
+    expect(mockConsoleFetch).toHaveBeenCalledWith(
+      'https://example.com',
+      'GET',
+      { signal: expect.any(AbortSignal) },
+      undefined,
+    );
+  });
+
+  it('should handle errors and convert them to FetchError', async () => {
+    const error = new Error('Network error');
+    mockConsoleFetch.mockRejectedValue(error);
+
+    const { request } = cancellableFetch('https://example.com');
+
+    await expect(request()).rejects.toThrow('Network error');
+
+    try {
+      await request();
+    } catch (err) {
+      expect(isFetchError(err)).toBe(true);
+    }
+  });
+
+  it('should handle abort controller', async () => {
+    const abortError = new Error('AbortError');
+    abortError.name = 'AbortError';
+    mockConsoleFetch.mockImplementation(
+      (_url, _method, options) =>
+        new Promise((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => reject(abortError), { once: true });
+        }),
+    );
+
+    const { request, abort } = cancellableFetch('https://example.com');
+    const pendingRequest = request();
+    abort();
+
+    await expect(pendingRequest).rejects.toThrow('AbortError');
+  });
+
+  it('should work with POST method', async () => {
+    const mockResponse = { data: 'test' };
+
+    // Test POST
+    mockPost.mockResolvedValueOnce(mockResponse);
+    const postRequest = cancellableFetch('https://example.com', { method: 'POST', body: '{}' });
+    await postRequest.request();
+    expect(mockPost).toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/loki-client.spec.ts
+++ b/web/src/__tests__/loki-client.spec.ts
@@ -1,7 +1,10 @@
 import { SchemaConfig } from '../logs.types';
 import { getFetchConfig } from '../loki-client';
 
-jest.mock('@openshift-console/dynamic-plugin-sdk');
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  consoleFetchJSON: jest.fn(),
+  K8sResourceCommon: {},
+}));
 
 describe('Loki Client', () => {
   it('should generate a valid config', () => {
@@ -15,7 +18,8 @@ describe('Loki Client', () => {
         },
         expectedFetchConfig: {
           endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/application',
-          requestInit: { timeout: undefined },
+          requestInit: {},
+          timeout: undefined,
         },
       },
       {
@@ -26,6 +30,7 @@ describe('Loki Client', () => {
         expectedFetchConfig: {
           endpoint: '/api/proxy/plugin/logging-view-plugin/backend',
           requestInit: { headers: { 'X-Scope-OrgID': 'application' } },
+          timeout: undefined,
         },
       },
       {
@@ -35,7 +40,8 @@ describe('Loki Client', () => {
         },
         expectedFetchConfig: {
           endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure',
-          requestInit: { timeout: undefined },
+          requestInit: {},
+          timeout: undefined,
         },
       },
       {
@@ -50,7 +56,8 @@ describe('Loki Client', () => {
         },
         expectedFetchConfig: {
           endpoint: '/api/proxy/plugin/logging-view-plugin/backend/api/logs/v1/infrastructure',
-          requestInit: { timeout: 2000 },
+          requestInit: {},
+          timeout: 2000,
         },
       },
     ].forEach(({ config, expectedFetchConfig }) => {

--- a/web/src/cancellable-fetch.ts
+++ b/web/src/cancellable-fetch.ts
@@ -1,29 +1,15 @@
+import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
+
 export type CancellableFetch<T> = {
   request: () => Promise<T>;
   abort: () => void;
 };
-
-export type RequestInitWithTimeout = RequestInit & { timeout?: number };
 
 class TimeoutError extends Error {
   constructor(url: string, ms: number) {
     super(`Request: ${url} timed out after ${ms}ms.`);
   }
 }
-
-const getCSRFToken = () => {
-  const cookiePrefix = 'csrf-token=';
-  return (
-    document &&
-    document.cookie &&
-    document.cookie
-      .split(';')
-      .map((c) => c.trim())
-      .filter((c) => c.startsWith(cookiePrefix))
-      .map((c) => c.slice(cookiePrefix.length))
-      .pop()
-  );
-};
 
 class FetchError extends Error {
   status: number;
@@ -37,45 +23,70 @@ class FetchError extends Error {
 }
 
 export const isFetchError = (error: unknown): error is FetchError =>
-  !!(error as FetchError).name && (error as FetchError).name === 'Fetch Error';
+  !!error &&
+  typeof error === 'object' &&
+  'name' in error &&
+  (error as FetchError).name === 'Fetch Error';
 
 export const cancellableFetch = <T>(
   url: string,
-  init?: RequestInitWithTimeout,
+  init?: RequestInit,
+  timeout?: number,
 ): CancellableFetch<T> => {
   const abortController = new AbortController();
   const abort = () => abortController.abort();
 
-  const fetchPromise = async () => {
-    const response = await fetch(url, {
-      ...init,
-      headers: {
-        ...init?.headers,
-        Accept: 'application/json',
-        ...(init?.method === 'POST' ? { 'X-CSRFToken': getCSRFToken() } : {}),
-      },
-      signal: abortController.signal,
-    });
+  const fetchPromise = async (): Promise<T> => {
+    const requestTimeout = timeout ?? 30 * 1000;
 
-    if (!response.ok) {
-      const text = await response.text();
-      throw new FetchError(text, response.status);
+    try {
+      const method = init?.method || 'GET';
+
+      const options: RequestInit = {
+        ...init,
+        signal: abortController.signal,
+      };
+
+      let result: T;
+
+      if (method.toUpperCase() === 'POST') {
+        result = await consoleFetchJSON.post(
+          url,
+          init?.body,
+          options,
+          requestTimeout > 0 ? requestTimeout : undefined,
+        );
+      } else {
+        result = await consoleFetchJSON(
+          url,
+          method,
+          options,
+          requestTimeout > 0 ? requestTimeout : undefined,
+        );
+      }
+
+      return result;
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          throw error;
+        }
+
+        if (error.message.includes('timed out') || error.message.includes('timeout')) {
+          throw new TimeoutError(url.toString(), requestTimeout);
+        }
+
+        const errorWithStatus = error as Error & {
+          status?: number;
+          response?: { status?: number };
+        };
+        const status = errorWithStatus.status || errorWithStatus.response?.status || 500;
+        throw new FetchError(error.message, status);
+      }
+
+      throw new FetchError('Network error', 500);
     }
-    return response.json();
   };
 
-  const timeout = init?.timeout ?? 30 * 1000;
-
-  if (timeout <= 0) {
-    return { request: fetchPromise, abort };
-  }
-
-  const timeoutPromise = () =>
-    new Promise<T>((_resolve, reject) => {
-      setTimeout(() => reject(new TimeoutError(url.toString(), timeout)), timeout);
-    });
-
-  const request = () => Promise.race([fetchPromise(), timeoutPromise()]);
-
-  return { request, abort };
+  return { request: fetchPromise, abort };
 };

--- a/web/src/loki-client.ts
+++ b/web/src/loki-client.ts
@@ -1,6 +1,6 @@
 import { WSFactory } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/ws-factory';
 import { queryWithNamespace } from './attribute-filters';
-import { CancellableFetch, cancellableFetch, RequestInitWithTimeout } from './cancellable-fetch';
+import { CancellableFetch, cancellableFetch } from './cancellable-fetch';
 import {
   Config,
   Direction,
@@ -68,22 +68,23 @@ export const getFetchConfig = ({
   config?: Config;
   tenant: string;
   endpoint?: string;
-}): { requestInit?: RequestInitWithTimeout; endpoint: string } => {
+}): { requestInit?: RequestInit; endpoint: string; timeout?: number } => {
+  const timeout = config?.timeout ? config.timeout * 1000 : undefined;
+
   if (config && config.useTenantInHeader === true) {
     return {
       requestInit: {
         headers: { 'X-Scope-OrgID': tenant },
-        timeout: config?.timeout ? config.timeout * 1000 : undefined,
       },
       endpoint: LOKI_ENDPOINT,
+      timeout,
     };
   }
 
   return {
-    requestInit: {
-      timeout: config?.timeout ? config.timeout * 1000 : undefined,
-    },
+    requestInit: {},
     endpoint: `${LOKI_ENDPOINT}/api/logs/v1/${tenant}`,
+    timeout,
   };
 };
 
@@ -98,7 +99,7 @@ export const executeLabelValue = ({
   config?: Config;
   tenant: string;
 }): CancellableFetch<LabelValueResponse> => {
-  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+  const { endpoint, requestInit, timeout } = getFetchConfig({ config, tenant });
 
   const params: Record<string, string> = {};
 
@@ -109,6 +110,7 @@ export const executeLabelValue = ({
   return cancellableFetch<LabelValueResponse>(
     `${endpoint}/loki/api/v1/label/${labelName}/values?${new URLSearchParams(params)}`,
     requestInit,
+    timeout,
   );
 };
 
@@ -121,7 +123,7 @@ export const executeSeries = ({
   config?: Config;
   tenant: string;
 }): CancellableFetch<SeriesResponse> => {
-  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+  const { endpoint, requestInit, timeout } = getFetchConfig({ config, tenant });
 
   const params: Record<string, string> = {};
 
@@ -132,6 +134,7 @@ export const executeSeries = ({
   return cancellableFetch<SeriesResponse>(
     `${endpoint}/loki/api/v1/series?${new URLSearchParams(params)}`,
     requestInit,
+    timeout,
   );
 };
 
@@ -162,11 +165,12 @@ export const executeQueryRange = ({
     params.direction = direction;
   }
 
-  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+  const { endpoint, requestInit, timeout } = getFetchConfig({ config, tenant });
 
   return cancellableFetch<QueryRangeResponse>(
     `${endpoint}/loki/api/v1/query_range?${new URLSearchParams(params)}`,
     requestInit,
+    timeout,
   );
 };
 
@@ -191,11 +195,12 @@ export const executeVolumeRange = ({
     end: endNs,
   };
 
-  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+  const { endpoint, requestInit, timeout } = getFetchConfig({ config, tenant });
 
   return cancellableFetch<VolumeRangeResponse>(
     `${endpoint}/loki/api/v1/index/volume_range?${new URLSearchParams(params)}`,
     requestInit,
+    timeout,
   );
 };
 
@@ -247,7 +252,7 @@ export const executeHistogramQuery = ({
     step: intervalString,
   };
 
-  const { endpoint, requestInit } = getFetchConfig({ config, tenant });
+  const { endpoint, requestInit, timeout } = getFetchConfig({ config, tenant });
 
   const timeRangeNs = BigInt(endNs) - BigInt(startNs);
 
@@ -267,6 +272,7 @@ export const executeHistogramQuery = ({
       const subQuery = cancellableFetch<QueryRangeResponse<MatrixResult>>(
         `${endpoint}/loki/api/v1/query_range?${new URLSearchParams(rangeParams)}`,
         requestInit,
+        timeout,
       );
 
       queries.push(subQuery);
@@ -307,6 +313,7 @@ export const executeHistogramQuery = ({
   return cancellableFetch<QueryRangeResponse<MatrixResult>>(
     `${endpoint}/loki/api/v1/query_range?${new URLSearchParams(params)}`,
     requestInit,
+    timeout,
   );
 };
 
@@ -354,7 +361,7 @@ export const getRules = ({
   tenant: string;
   namespace?: string;
 }) => {
-  const { endpoint, requestInit } = getFetchConfig({
+  const { endpoint, requestInit, timeout } = getFetchConfig({
     config,
     tenant,
   });
@@ -370,5 +377,5 @@ export const getRules = ({
     url = `${url}?${alertingRulesNamespaceLabelKey}=${namespace}`;
   }
 
-  return cancellableFetch<RulesResponse>(url, requestInit);
+  return cancellableFetch<RulesResponse>(url, requestInit, timeout);
 };


### PR DESCRIPTION
Remove the native fetch to use the console SDK fetch, this will include the required headers so the Loki backend can do a proper Subject Access Review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling for Loki queries, including GET and POST operations.
  * Added consistent timeout support with a 30-second default and clearer timeout errors.
  * Improved handling of cancelled requests, network failures, and HTTP error responses.
  * Preserved tenant-specific request routing and headers across Loki operations.

* **Tests**
  * Expanded coverage for cancellable requests, timeout behavior, error handling, and Loki request configuration.
  * Improved test support for stylesheet imports and platform API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->