### PR TITLE
NO-JIRA: Backport CSV sanitization to 4.15

### DIFF
--- a/web/cypress/e2e/integration/logs-dev-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-dev-page.cy.ts
@@ -410,7 +410,9 @@ describe('Logs Dev Page', () => {
       QUERY_RANGE_STREAMS_URL_MATCH,
       queryRangeStreamsValidResponse({ message: TEST_MESSAGE }),
     );
-    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse());
+    cy.intercept(QUERY_RANGE_MATRIX_URL_MATCH, queryRangeMatrixValidResponse()).as(
+      'queryRangeMatrix',
+    );
 
     cy.visit(LOGS_DEV_PAGE_URL);
 
@@ -437,6 +439,8 @@ describe('Logs Dev Page', () => {
     });
 
     cy.getByTestId(TestIds.ExecuteQueryButton).click();
+
+    cy.wait('@queryRangeMatrix');
 
     cy.getByTestId(TestIds.LogsMetrics).should('exist');
     cy.getByTestId(TestIds.ToggleHistogramButton).should('be.disabled');

--- a/web/cypress/e2e/integration/logs-page.cy.ts
+++ b/web/cypress/e2e/integration/logs-page.cy.ts
@@ -271,6 +271,8 @@ describe('Logs Page', () => {
     cy.getByTestId(TestIds.TenantToggle).click();
     cy.contains('infrastructure').click();
 
+    cy.wait('@queryRangeStreamsInfrastructure');
+
     cy.getByTestId(TestIds.ExecuteQueryButton).click();
 
     cy.getByTestId(TestIds.LogsHistogram)

--- a/web/src/__tests__/download-csv.spec.ts
+++ b/web/src/__tests__/download-csv.spec.ts
@@ -25,8 +25,8 @@ describe('download CSV', () => {
         data: '=HYPERLINK("http://test.com","Click")',
         escapedData: `"'=HYPERLINK(""http://test.com"",""Click"")"`,
       },
-      { data: '\tcmd', escapedData: "'\tcmd" },
-      { data: '\rcmd', escapedData: `"'\\rcmd"` },
+      { data: '\tcmd', escapedData: 'cmd' },
+      { data: '\rcmd', escapedData: 'cmd' },
     ].forEach(({ data, escapedData }) => {
       expect(escapeCSVValue(data)).toEqual(escapedData);
     });
@@ -548,8 +548,8 @@ describe('download CSV', () => {
 100,'+val,'=1+1,
 101,'+val,'-1+1,
 102,'+val,'@SUM(A1),
-103,'+val,'\tcmd,
-104,'+val,"'\\rcmd",
+103,'+val,cmd,
+104,'+val,cmd,
 `,
       },
       {
@@ -576,8 +576,8 @@ describe('download CSV', () => {
         csv: `time,y,'-col
 100,'=1+1,'@val,
 101,'+1+1,'@val,
-102,'\tcmd,'@val,
-103,"'\\rcmd",'@val,
+102,cmd,'@val,
+103,cmd,'@val,
 `,
       },
     ].forEach(({ response, csv }) => {

--- a/web/src/__tests__/download-csv.spec.ts
+++ b/web/src/__tests__/download-csv.spec.ts
@@ -522,6 +522,64 @@ describe('download CSV', () => {
 1738136036,0.041666666666666664,,
 `,
       },
+      {
+        response: {
+          status: 'success',
+          data: {
+            resultType: 'streams',
+            result: [
+              {
+                stream: {
+                  '=col': '+val',
+                },
+                values: [
+                  ['100', '=1+1'],
+                  ['101', '-1+1'],
+                  ['102', '@SUM(A1)'],
+                  ['103', '\tcmd'],
+                  ['104', '\rcmd'],
+                ],
+              },
+            ],
+            stats: {},
+          },
+        },
+        csv: `time,'=col,raw
+100,'+val,'=1+1,
+101,'+val,'-1+1,
+102,'+val,'@SUM(A1),
+103,'+val,'\tcmd,
+104,'+val,"'\\rcmd",
+`,
+      },
+      {
+        response: {
+          status: 'success',
+          data: {
+            resultType: 'matrix',
+            result: [
+              {
+                metric: {
+                  '-col': '@val',
+                },
+                values: [
+                  [100, '=1+1'],
+                  [101, '+1+1'],
+                  [102, '\tcmd'],
+                  [103, '\rcmd'],
+                ],
+              },
+            ],
+            stats: {},
+          },
+        },
+        csv: `time,y,'-col
+100,'=1+1,'@val,
+101,'+1+1,'@val,
+102,'\tcmd,'@val,
+103,"'\\rcmd",'@val,
+`,
+      },
     ].forEach(({ response, csv }) => {
       expect(csvFromQueryResponse(response as QueryRangeResponse)).toEqual(csv);
     });

--- a/web/src/__tests__/download-csv.spec.ts
+++ b/web/src/__tests__/download-csv.spec.ts
@@ -16,6 +16,17 @@ describe('download CSV', () => {
         data: `{"count":0,"host":"2a1b688652c6.1.00000000000000007A44C9E5C6264200","lvl":"warn","msg":"OS not found try installing one","stream":"stdout","ts":"2025-01-29T07:23:52.6392194{"coun{"count":1,"host":"2a1b688652c6.1.00000000000000007A44C9E5C6264200","lvl":"debug","msg":"failed to reach the cloud, try again on a rainy day","stream":"s{"count":2,"host":"2a1b688652c6.0.000000000000{"count":2,"host":"2a1b688652c6.1.00000000000000007A44C9E5C6264200","lvl":"error","msg":"failing to cook potatoes","stream":"stdout","ts"{"co{"count":3,"host":"2a1b688652c6.0.00000000000000004D08FC57CDAD6659","lvl":"error","msg":"failing to cook potatoes","stream":"stdout","ts":"2025-01-29T07:23:52.657082657{"co{"count":4,"host":"2a1b688652c6.0.00000000000000004D08FC57CDAD6659","lvl":"debug","msg":"random error happened during compression","stream":"stdout","ts":"2025-01-29T07:23:52.657454906Z"}`,
         escapedData: `"{""count"":0,""host"":""2a1b688652c6.1.00000000000000007A44C9E5C6264200"",""lvl"":""warn"",""msg"":""OS not found try installing one"",""stream"":""stdout"",""ts"":""2025-01-29T07:23:52.6392194{""coun{""count"":1,""host"":""2a1b688652c6.1.00000000000000007A44C9E5C6264200"",""lvl"":""debug"",""msg"":""failed to reach the cloud, try again on a rainy day"",""stream"":""s{""count"":2,""host"":""2a1b688652c6.0.000000000000{""count"":2,""host"":""2a1b688652c6.1.00000000000000007A44C9E5C6264200"",""lvl"":""error"",""msg"":""failing to cook potatoes"",""stream"":""stdout"",""ts""{""co{""count"":3,""host"":""2a1b688652c6.0.00000000000000004D08FC57CDAD6659"",""lvl"":""error"",""msg"":""failing to cook potatoes"",""stream"":""stdout"",""ts"":""2025-01-29T07:23:52.657082657{""co{""count"":4,""host"":""2a1b688652c6.0.00000000000000004D08FC57CDAD6659"",""lvl"":""debug"",""msg"":""random error happened during compression"",""stream"":""stdout"",""ts"":""2025-01-29T07:23:52.657454906Z""}"`,
       },
+      { data: '=', escapedData: "'=" },
+      { data: '=1+1', escapedData: "'=1+1" },
+      { data: '+1+1', escapedData: "'+1+1" },
+      { data: '-1+1', escapedData: "'-1+1" },
+      { data: '@SUM(A1:A2)', escapedData: "'@SUM(A1:A2)" },
+      {
+        data: '=HYPERLINK("http://test.com","Click")',
+        escapedData: `"'=HYPERLINK(""http://test.com"",""Click"")"`,
+      },
+      { data: '\tcmd', escapedData: "'\tcmd" },
+      { data: '\rcmd', escapedData: `"'\\rcmd"` },
     ].forEach(({ data, escapedData }) => {
       expect(escapeCSVValue(data)).toEqual(escapedData);
     });

--- a/web/src/download-csv.ts
+++ b/web/src/download-csv.ts
@@ -9,7 +9,12 @@ export const escapeCSVValue = (value: string | number) => {
     return '';
   }
 
-  const stringValue = String(value);
+  let stringValue = String(value);
+
+  if (/^[=+\-@\t\r]/.test(stringValue)) {
+    stringValue = "'" + stringValue;
+  }
+
   if (stringValue.includes('"')) {
     return `"${stringValue.replace(/"/g, '""')}"`;
   }
@@ -33,13 +38,13 @@ export const csvFromQueryResponse = (response?: QueryRangeResponse): string => {
 
     const uniqueColumns = Array.from(['time', ...new Set(columns), 'raw']);
 
-    csvData += uniqueColumns.join(',') + '\n';
+    csvData += uniqueColumns.map((col) => escapeCSVValue(col)).join(',') + '\n';
 
     for (const res of response.data.result) {
       for (const value of res.values) {
         for (const col of uniqueColumns) {
           if (col === 'time') {
-            csvData += value?.[0] + ',';
+            csvData += escapeCSVValue(value?.[0]) + ',';
             continue;
           }
 
@@ -58,18 +63,18 @@ export const csvFromQueryResponse = (response?: QueryRangeResponse): string => {
 
     const uniqueColumns = Array.from(['time', 'y', ...new Set(columns)]);
 
-    csvData += uniqueColumns.join(',') + '\n';
+    csvData += uniqueColumns.map((col) => escapeCSVValue(col)).join(',') + '\n';
 
     for (const res of response.data.result) {
       for (const value of res.values) {
         for (const col of uniqueColumns) {
           if (col === 'time') {
-            csvData += value[0] + ',';
+            csvData += escapeCSVValue(value[0]) + ',';
             continue;
           }
 
           if (col === 'y') {
-            csvData += value[1] + ',';
+            csvData += escapeCSVValue(value[1]) + ',';
             continue;
           }
 

--- a/web/src/download-csv.ts
+++ b/web/src/download-csv.ts
@@ -9,7 +9,7 @@ export const escapeCSVValue = (value: string | number) => {
     return '';
   }
 
-  let stringValue = String(value).trim()
+  let stringValue = String(value).trim();
 
   if (/^[=+\-@\t\r]/.test(stringValue)) {
     stringValue = "'" + stringValue;

--- a/web/src/download-csv.ts
+++ b/web/src/download-csv.ts
@@ -9,7 +9,7 @@ export const escapeCSVValue = (value: string | number) => {
     return '';
   }
 
-  let stringValue = String(value);
+  let stringValue = String(value).trim()
 
   if (/^[=+\-@\t\r]/.test(stringValue)) {
     stringValue = "'" + stringValue;


### PR DESCRIPTION
Backport of #396 (CSV sanitization fix) + e2e test fix from #389.

image: quay.io/jezhu/logging-view-plugin:sanitize-csv-cherrypick-4.15

## Cherry-picked commits
- `9e69291` fix: OU-1473 Sanitize CSV
- `c6332a0` fix: ou-1473 sanitize csv. add extra tests
- `1600c28` fix: Update web/src/download-csv.ts
- `fe13661` fix: ou1473-sanitize-csv. update test to align with .trim() during parsing
- `e85ff53` fix: update e2e tests to wait for response